### PR TITLE
Various MXF read over HTTP updates

### DIFF
--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -120,7 +120,7 @@ static const uint32_t DEFAULT_RW_INTL_SIZE  = (64 * 1024);
 static const uint16_t DEFAULT_RDD6_LINES[2] = {9, 572};     /* ST 274, line 9 field 1 and 2 */
 static const uint8_t DEFAULT_RDD6_SDID      = 4;            /* first channel pair is 5/6 */
 
-static const uint32_t DEFAULT_HTTP_MIN_READ = 64 * 1024;
+static const uint32_t DEFAULT_HTTP_MIN_READ = 1024 * 1024;
 
 
 namespace bmx

--- a/apps/mxf2raw/mxf2raw.cpp
+++ b/apps/mxf2raw/mxf2raw.cpp
@@ -139,7 +139,7 @@ static const char *XML_INFO_WRITER_VERSION      = "0.1"; // format <major>.<mino
 
 static const char* STDIN_FILENAME = "stdin:";
 
-static const uint32_t DEFAULT_HTTP_MIN_READ = 64 * 1024;
+static const uint32_t DEFAULT_HTTP_MIN_READ = 1024 * 1024;
 
 
 namespace bmx

--- a/src/common/MXFHTTPFile.cpp
+++ b/src/common/MXFHTTPFile.cpp
@@ -101,9 +101,9 @@ static size_t curl_file_size_header_cb(char *buffer, size_t size, size_t nmemb, 
 {
   int64_t *file_size_out = (int64_t*)priv;
 
-  const string header_str(buffer, size * nmemb);
+  string header_str = lowercase(string(buffer, size * nmemb));
 
-  size_t fidx = get_http_field_value_pos(header_str, "Content-Length");
+  size_t fidx = get_http_field_value_pos(header_str, "content-length");
   if (fidx != string::npos) {
       int64_t content_length;
       if (sscanf(&header_str.c_str()[fidx], "%" PRId64, &content_length) == 1)
@@ -117,16 +117,16 @@ static size_t curl_header_cb(char *buffer, size_t size, size_t nmemb, void *priv
 {
   CURLReceiveInfo *info = (CURLReceiveInfo*)priv;
 
-  const string header_str(buffer, size * nmemb);
+  string header_str = lowercase(string(buffer, size * nmemb));
 
-  size_t fidx = get_http_field_value_pos(header_str, "Accept-Ranges");
+  size_t fidx = get_http_field_value_pos(header_str, "accept-ranges");
   if (fidx != string::npos) {
       info->accept_range_recv = true;
       if (header_str.compare(fidx, 5, "bytes"))
           info->accept_bytes_range = true;
   }
 
-  fidx = get_http_field_value_pos(header_str, "Content-Range");
+  fidx = get_http_field_value_pos(header_str, "content-range");
   if (fidx != string::npos) {
       int64_t first;
       if (sscanf(&header_str.c_str()[fidx], "%" PRId64, &first) == 1) {


### PR DESCRIPTION
This PR adds various updates to the MXF read over HTTP code:
* Change to case-insensitive comparisons for the HTTP headers
* Fallback to a GET request to get the file size (Content Length) if a HEAD request fails. This supports pre-signed URLs that restrict the request method
* Workaround a 1 hour timeout seen on Google storage API over HTTP2 resulting in a non-specific CURLE_HTTP2 error
* Change the minimum read size from 64K to 1MB to improve the read speed