### PR TITLE
Improve RDD 9 partition duration

### DIFF
--- a/src/rdd9_mxf/RDD9File.cpp
+++ b/src/rdd9_mxf/RDD9File.cpp
@@ -793,7 +793,7 @@ void RDD9File::WriteContentPackages(bool final_write)
         // start body partition at first write or when # frames per partition close to exceeding maximum
         if (mFirstWrite ||
             (mPartitionInterval > 0 && mPartitionFrameCount > 0 &&
-                mPartitionFrameCount + MAX_GOP_SIZE >= mPartitionInterval && mIndexTable->CanStartPartition()))
+                mPartitionFrameCount >= mPartitionInterval && mIndexTable->CanStartPartition()))
         {
             mMXFFile->openMemoryFile(MEMORY_WRITE_CHUNK_SIZE);
 

--- a/test/as10/test_as10.cmake
+++ b/test/as10/test_as10.cmake
@@ -35,7 +35,7 @@ set(create_command ${RAW2BMX}
     -f 25
     -y 22:22:22:22
     --single-pass
-    --part 25
+    --part 12
     -o ${output_file_1}
     --dm-file as10 ${TEST_SOURCE_DIR}/as10_core_framework.txt
     --shim-name high_hd_2014


### PR DESCRIPTION
This PR ensures that the partition duration matches the value in RDD 9 2013, Table B.2 for fixed GOP sizes that divide into the partition frame counts and for compliant frame rates.

RDD 9 files with variable GOP sizes for example may end up having partition durations just over 10 seconds. However, the 10 second target is an approximation, not a hard limit.

The AS-10 test needed to be changed because of the way that the partition logic changed.

Fixes https://github.com/bbc/bmx/issues/11