### PR TITLE
Allow faster file access over HTTP

### DIFF
--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -416,6 +416,8 @@ static void usage(const char *cmd)
     fprintf(stderr, "  --gf-delay <sec>        Set the delay (in seconds) between a failure to read and a retry. The default is %f.\n", DEFAULT_GF_RETRY_DELAY);
     fprintf(stderr, "  --gf-rate <factor>      Limit the read rate to realtime rate x <factor> after a read failure. The default is %f\n", DEFAULT_GF_RATE_AFTER_FAIL);
     fprintf(stderr, "                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
+    fprintf(stderr, " --disable-indexing-file   Use this option to stop the reader creating an index of the partitions and essence positions in the file up front\n");
+    fprintf(stderr, "                           This option can be used to avoid indexing files containing many partitions\n");
     if (mxf_http_is_supported()) {
         fprintf(stderr, " --http-min-read <bytes>\n");
         fprintf(stderr, "                          Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
@@ -883,6 +885,7 @@ int main(int argc, const char** argv)
     unsigned int gf_retries = DEFAULT_GF_RETRIES;
     float gf_retry_delay = DEFAULT_GF_RETRY_DELAY;
     float gf_rate_after_fail = DEFAULT_GF_RATE_AFTER_FAIL;
+    bool enable_indexing_file = true;
     bool product_info_set = false;
     string company_name;
     string product_name;
@@ -1264,6 +1267,10 @@ int main(int argc, const char** argv)
             }
             growing_file = true;
             cmdln_index++;
+        }
+        else if (strcmp(argv[cmdln_index], "--disable-indexing-file") == 0)
+        {
+            enable_indexing_file = false;
         }
         else if (strcmp(argv[cmdln_index], "--http-min-read") == 0)
         {
@@ -2876,6 +2883,7 @@ int main(int argc, const char** argv)
                 grp_file_reader->SetFileFactory(&file_factory, false);
                 grp_file_reader->GetPackageResolver()->SetFileFactory(&file_factory, false);
                 grp_file_reader->SetST436ManifestFrameCount(st436_manifest_count);
+                grp_file_reader->SetEnableIndexFile(enable_indexing_file);
                 result = grp_file_reader->Open(input_filenames[i]);
                 if (result != MXFFileReader::MXF_RESULT_SUCCESS) {
                     log_error("Failed to open MXF file '%s': %s\n", input_filenames[i],
@@ -2899,6 +2907,7 @@ int main(int argc, const char** argv)
                 seq_file_reader->SetFileFactory(&file_factory, false);
                 seq_file_reader->GetPackageResolver()->SetFileFactory(&file_factory, false);
                 seq_file_reader->SetST436ManifestFrameCount(st436_manifest_count);
+                seq_file_reader->SetEnableIndexFile(enable_indexing_file);
                 result = seq_file_reader->Open(input_filenames[i]);
                 if (result != MXFFileReader::MXF_RESULT_SUCCESS) {
                     log_error("Failed to open MXF file '%s': %s\n", input_filenames[i],
@@ -2919,6 +2928,7 @@ int main(int argc, const char** argv)
             file_reader->SetFileFactory(&file_factory, false);
             file_reader->GetPackageResolver()->SetFileFactory(&file_factory, false);
             file_reader->SetST436ManifestFrameCount(st436_manifest_count);
+            file_reader->SetEnableIndexFile(enable_indexing_file);
             if (pass_dm && clip_sub_type == AS11_CLIP_SUB_TYPE)
                 AS11Info::RegisterExtensions(file_reader->GetHeaderMetadata());
             if (pass_dm && clip_sub_type == AS10_CLIP_SUB_TYPE)
@@ -2940,7 +2950,7 @@ int main(int argc, const char** argv)
                 log_error("Input file is incomplete\n");
                 throw false;
             }
-            if (reader->IsSeekable())
+            if (reader->IsSeekable() && enable_indexing_file)
                 log_warn("Input file is incomplete\n");
             else
                 log_debug("Input file is incomplete, probably because the file is not seekable\n");

--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -403,7 +403,7 @@ static void usage(const char *cmd)
     fprintf(stderr, "  --dur <count>           Set the duration in input edit rate units. Default is minimum input duration\n");
     fprintf(stderr, "  --check-end             Check at the start that the last (start + duration - 1) edit unit can be read\n");
     fprintf(stderr, "  --check-end-tolerance <frame> Allow output duration shorter than input declared duration\n");
-    fprintf(stderr, "  --check-complete        Check that the input file is complete\n");
+    fprintf(stderr, "  --check-complete        Check that the input file structure can be read and is complete\n");
     fprintf(stderr, "  --group                 Use the group reader instead of the sequence reader\n");
     fprintf(stderr, "                          Use this option if the files have different material packages\n");
     fprintf(stderr, "                          but actually belong to the same virtual package / group\n");
@@ -2940,7 +2940,10 @@ int main(int argc, const char** argv)
                 log_error("Input file is incomplete\n");
                 throw false;
             }
-            log_warn("Input file is incomplete\n");
+            if (reader->IsSeekable())
+                log_warn("Input file is incomplete\n");
+            else
+                log_debug("Input file is incomplete, probably because the file is not seekable\n");
         }
 
         reader->SetEmptyFrames(true);

--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -419,6 +419,7 @@ static void usage(const char *cmd)
     if (mxf_http_is_supported()) {
         fprintf(stderr, " --http-min-read <bytes>\n");
         fprintf(stderr, "                          Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
+        fprintf(stderr, " --http-disable-seek      Disable seeking when reading file over HTTP\n");
     }
     fprintf(stderr, "  --no-precharge          Don't output clip/track with precharge. Adjust the start position and duration instead\n");
     fprintf(stderr, "  --no-rollout            Don't output clip/track with rollout. Adjust the duration instead\n");
@@ -906,6 +907,7 @@ int main(int argc, const char** argv)
     uint16_t rdd6_lines[2] = {DEFAULT_RDD6_LINES[0], DEFAULT_RDD6_LINES[1]};
     uint8_t rdd6_sdid = DEFAULT_RDD6_SDID;
     uint32_t http_min_read = DEFAULT_HTTP_MIN_READ;
+    bool http_enable_seek = true;
     bool mp_track_num = false;
 #if defined(_WIN32) && !defined(__MINGW32__)
     bool use_mmap_file = false;
@@ -1279,6 +1281,10 @@ int main(int argc, const char** argv)
             }
             http_min_read = (uint32_t)(uvalue);
             cmdln_index++;
+        }
+        else if (strcmp(argv[cmdln_index], "--http-disable-seek") == 0)
+        {
+            http_enable_seek = false;
         }
         else if (strcmp(argv[cmdln_index], "--no-precharge") == 0)
         {
@@ -2856,6 +2862,7 @@ int main(int argc, const char** argv)
         if (rw_interleave)
             file_factory.SetRWInterleave(rw_interleave_size);
         file_factory.SetHTTPMinReadSize(http_min_read);
+        file_factory.SetHTTPEnableSeek(http_enable_seek);
 #if defined(_WIN32) && !defined(__MINGW32__)
         file_factory.SetUseMMapFile(use_mmap_file);
 #endif

--- a/apps/mxf2raw/mxf2raw.cpp
+++ b/apps/mxf2raw/mxf2raw.cpp
@@ -1624,7 +1624,7 @@ static void usage(const char *cmd)
     fprintf(stderr, "                       Use this option for files with broken timecode\n");
     fprintf(stderr, "\n");
     fprintf(stderr, " --check-end           Check that the last edit unit (start + duration - 1) can be read when opening the files\n");
-    fprintf(stderr, " --check-complete      Check that the input files are complete\n");
+    fprintf(stderr, " --check-complete      Check that the input file structure info can be read and is complete\n");
     fprintf(stderr, " --check-app-issues    Check that there are no known issues with the APP (Archive Preservation Project) file\n");
     fprintf(stderr, " --check-app-crc32     Check APP essence CRC-32 data\n");
     fprintf(stderr, "\n");
@@ -2501,7 +2501,7 @@ int main(int argc, const char** argv)
             if (reader->IsSeekable())
                 log_warn("Input file is incomplete\n");
             else
-                log_debug("Input file is not seekable\n");
+                log_debug("Input file is incomplete, probably because the file is not seekable\n");
         }
 
         mxfRational edit_rate = reader->GetEditRate();

--- a/apps/mxf2raw/mxf2raw.cpp
+++ b/apps/mxf2raw/mxf2raw.cpp
@@ -1690,6 +1690,7 @@ static void usage(const char *cmd)
     if (mxf_http_is_supported()) {
         fprintf(stderr, " --http-min-read <bytes>\n");
         fprintf(stderr, "                       Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
+        fprintf(stderr, " --http-disable-seek   Disable seeking when reading file over HTTP\n");
     }
     fprintf(stderr, "\n");
     fprintf(stderr, " --text-out <prefix>   Extract text based objects to files starting with <prefix>\n");
@@ -1762,6 +1763,7 @@ int main(int argc, const char** argv)
     float gf_retry_delay = DEFAULT_GF_RETRY_DELAY;
     float gf_rate_after_fail = DEFAULT_GF_RATE_AFTER_FAIL;
     uint32_t http_min_read = DEFAULT_HTTP_MIN_READ;
+    bool http_enable_seek = true;
     ChecksumType checkum_type;
 #if defined(_WIN32) && !defined(__MINGW32__)
     bool use_mmap_file = false;
@@ -2249,6 +2251,10 @@ int main(int argc, const char** argv)
             http_min_read = (uint32_t)(uvalue);
             cmdln_index++;
         }
+        else if (strcmp(argv[cmdln_index], "--http-disable-seek") == 0)
+        {
+            http_enable_seek = false;
+        }
         else if (strcmp(argv[cmdln_index], "--regtest") == 0)
         {
             BMX_REGRESSION_TEST = true;
@@ -2409,6 +2415,7 @@ int main(int argc, const char** argv)
             file_factory.SetInputChecksumTypes(file_checksum_types);
         file_factory.SetInputFlags(file_flags);
         file_factory.SetHTTPMinReadSize(http_min_read);
+        file_factory.SetHTTPEnableSeek(http_enable_seek);
 #if defined(_WIN32) && !defined(__MINGW32__)
         file_factory.SetUseMMapFile(use_mmap_file);
 #endif

--- a/apps/mxf2raw/mxf2raw.cpp
+++ b/apps/mxf2raw/mxf2raw.cpp
@@ -1708,6 +1708,7 @@ static void usage(const char *cmd)
 
 int main(int argc, const char** argv)
 {
+    bool have_action = false;  // true when an option is selected to take a specific action
     std::vector<const char *> input_filenames;
     const char *log_filename = 0;
     LogLevel log_level = INFO_LOG;
@@ -1795,6 +1796,7 @@ int main(int argc, const char** argv)
                 return 0;
             }
             fprintf(stderr, "%s\n", get_app_version_info(APP_NAME).c_str());
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "-l") == 0)
         {
@@ -1838,6 +1840,7 @@ int main(int argc, const char** argv)
                 return 1;
             }
             file_checksum_only_types.insert(checkum_type);
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--group") == 0)
@@ -1851,25 +1854,30 @@ int main(int argc, const char** argv)
         else if (strcmp(argv[cmdln_index], "--check-end") == 0)
         {
             check_end = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--check-complete") == 0)
         {
             check_complete = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--check-app-issues") == 0)
         {
             check_app_issues = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--check-app-crc32") == 0)
         {
             check_app_crc32 = true;
             do_ess_read = true;
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "-i") == 0 ||
                  strcmp(argv[cmdln_index], "--info") == 0)
         {
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--info-format") == 0)
         {
@@ -1917,6 +1925,7 @@ int main(int argc, const char** argv)
             track_checksum_types.insert(checkum_type);
             do_write_info = true;
             do_ess_read = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--file-chksum") == 0)
@@ -1935,22 +1944,26 @@ int main(int argc, const char** argv)
             }
             file_checksum_types.insert(checkum_type);
             do_write_info = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--as11") == 0)
         {
             do_as11_info = true;
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--as10") == 0)
         {
             do_as10_info = true;
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--app") == 0)
         {
             do_app_info = true;
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--app-events") == 0)
         {
@@ -1968,6 +1981,7 @@ int main(int argc, const char** argv)
             }
             do_app_info = true;
             do_write_info = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--no-app-events-tc") == 0)
@@ -1984,6 +1998,7 @@ int main(int argc, const char** argv)
             }
             app_crc32_filename = argv[cmdln_index + 1];
             do_ess_read = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--app-tc") == 0)
@@ -1996,6 +2011,7 @@ int main(int argc, const char** argv)
             }
             app_tc_filename = argv[cmdln_index + 1];
             do_ess_read = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--all-tc") == 0)
@@ -2008,6 +2024,7 @@ int main(int argc, const char** argv)
             }
             all_tc_filename = argv[cmdln_index + 1];
             do_ess_read = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--index") == 0)
@@ -2015,11 +2032,13 @@ int main(int argc, const char** argv)
             do_index_info = true;
             do_write_info = true;
             do_parse_read = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--avid") == 0)
         {
             do_avid_info = true;
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--st436-mf") == 0)
         {
@@ -2037,6 +2056,7 @@ int main(int argc, const char** argv)
             }
             st436_manifest_count = (uint32_t)(uvalue);
             do_write_info = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--rdd6") == 0)
@@ -2054,12 +2074,14 @@ int main(int argc, const char** argv)
                 return 1;
             }
             rdd6_filename = argv[cmdln_index + 2];
+            have_action = true;
             cmdln_index += 2;
         }
         else if (strcmp(argv[cmdln_index], "--mca-detail") == 0)
         {
             mca_detail = true;
             do_write_info = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "-p") == 0 ||
                  strcmp(argv[cmdln_index], "--ess-out") == 0)
@@ -2072,6 +2094,7 @@ int main(int argc, const char** argv)
             }
             ess_output_prefix = argv[cmdln_index + 1];
             do_ess_read = true;
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--wrap-klv") == 0)
@@ -2093,6 +2116,7 @@ int main(int argc, const char** argv)
         else if (strcmp(argv[cmdln_index], "--read-ess") == 0)
         {
             do_ess_read = true;
+            have_action = true;
         }
         else if (strcmp(argv[cmdln_index], "--deint") == 0)
         {
@@ -2232,6 +2256,7 @@ int main(int argc, const char** argv)
                 return 1;
             }
             text_output_prefix = argv[cmdln_index + 1];
+            have_action = true;
             cmdln_index++;
         }
         else if (strcmp(argv[cmdln_index], "--http-min-read") == 0)
@@ -2275,8 +2300,8 @@ int main(int argc, const char** argv)
         return 1;
     }
 
-    if (cmdln_index == 1) {
-        // default to outputting info if no options are given
+    if (!have_action) {
+        // default to outputting info if no specific action has been selected
         do_write_info = true;
     }
 

--- a/include/bmx/MXFHTTPFile.h
+++ b/include/bmx/MXFHTTPFile.h
@@ -45,7 +45,7 @@ bool mxf_http_is_supported();
 
 bool mxf_http_is_url(const std::string &url_str);
 
-MXFFile* mxf_http_file_open_read(const std::string &url_str, uint32_t min_read_size);
+MXFFile* mxf_http_file_open_read(const std::string &url_str, uint32_t min_read_size, bool enable_seek);
 
 
 };

--- a/include/bmx/apps/AppMXFFileFactory.h
+++ b/include/bmx/apps/AppMXFFileFactory.h
@@ -66,6 +66,7 @@ public:
     void SetInputFlags(int flags);
     void SetRWInterleave(uint32_t rw_interleave_size);
     void SetHTTPMinReadSize(uint32_t size);
+    void SetHTTPEnableSeek(bool enable);  // Default true
 #if defined(_WIN32) && !defined(__MINGW32__)
     void SetUseMMapFile(bool enable);
 #endif
@@ -105,6 +106,7 @@ private:
     std::vector<InputChecksumFile> mInputChecksumFiles;
     MXFRWInterleaver *mRWInterleaver;
     uint32_t mHTTPMinReadSize;
+    bool mHTTPEnableSeek;
 #if defined(_WIN32) && !defined(__MINGW32__)
     bool mUseMMapFile;
 #endif

--- a/include/bmx/mxf_reader/MXFFileReader.h
+++ b/include/bmx/mxf_reader/MXFFileReader.h
@@ -99,6 +99,7 @@ public:
     void SetST436ManifestFrameCount(uint32_t count);     // default: 2 frames used to extract manifest
     virtual void SetFileIndex(MXFFileIndex *file_index, bool take_ownership);
     virtual void SetMCALabelIndex(MXFMCALabelIndex *label_index, bool take_ownership);
+    void SetEnableIndexFile(bool enable);  // Default true
 
     OpenResult Open(std::string filename, int mode_flags=0);
     OpenResult Open(mxfpp::File *file, std::string filename, int mode_flags=0);
@@ -259,6 +260,7 @@ private:
     std::vector<MXFTextObject*> mTextObjects; // internal and external text objects
     std::vector<MXFTextObject*> mInternalTextObjects;
 
+    bool mEnableIndexFile;
     EssenceReader *mEssenceReader;
 
     uint32_t mRequireFrameInfoCount;

--- a/src/apps/AppMXFFileFactory.cpp
+++ b/src/apps/AppMXFFileFactory.cpp
@@ -53,7 +53,7 @@ AppMXFFileFactory::AppMXFFileFactory()
 {
     mInputFlags = 0;
     mRWInterleaver = 0;
-    mHTTPMinReadSize = 64 * 1024;
+    mHTTPMinReadSize = 1024 * 1024;
     mHTTPEnableSeek = true;
 #if defined(_WIN32) && !defined(__MINGW32__)
     mUseMMapFile = false;

--- a/src/apps/AppMXFFileFactory.cpp
+++ b/src/apps/AppMXFFileFactory.cpp
@@ -54,6 +54,7 @@ AppMXFFileFactory::AppMXFFileFactory()
     mInputFlags = 0;
     mRWInterleaver = 0;
     mHTTPMinReadSize = 64 * 1024;
+    mHTTPEnableSeek = true;
 #if defined(_WIN32) && !defined(__MINGW32__)
     mUseMMapFile = false;
 #endif
@@ -96,6 +97,11 @@ void AppMXFFileFactory::SetRWInterleave(uint32_t rw_interleave_size)
 void AppMXFFileFactory::SetHTTPMinReadSize(uint32_t size)
 {
     mHTTPMinReadSize = size;
+}
+
+void AppMXFFileFactory::SetHTTPEnableSeek(bool enable)
+{
+    mHTTPEnableSeek = enable;
 }
 
 #if defined(_WIN32) && !defined(__MINGW32__)
@@ -152,7 +158,7 @@ File* AppMXFFileFactory::OpenRead(string filename)
             uri_str = "stdin:";
         } else {
             if (mxf_http_is_url(filename)) {
-                mxf_file = mxf_http_file_open_read(filename, mHTTPMinReadSize);
+                mxf_file = mxf_http_file_open_read(filename, mHTTPMinReadSize, mHTTPEnableSeek);
                 uri_str = filename;
             } else {
 #if defined(_WIN32)

--- a/src/common/MXFHTTPFile.cpp
+++ b/src/common/MXFHTTPFile.cpp
@@ -44,6 +44,7 @@
 #include <curl/curl.h>
 
 #include <mxf/mxf.h>
+#include <mxf/mxf_stream_file.h>
 
 #include <bmx/MXFHTTPFile.h>
 #include <bmx/Utils.h>
@@ -452,7 +453,7 @@ bool bmx::mxf_http_is_url(const string &url_str)
            url_str.compare(0, 8, "https://") == 0;
 }
 
-MXFFile* bmx::mxf_http_file_open_read(const string &url_str, uint32_t min_read_size)
+MXFFile* bmx::mxf_http_file_open_read(const string &url_str, uint32_t min_read_size, bool enable_seek)
 {
     MXFFile *http_file = 0;
     try
@@ -490,7 +491,13 @@ MXFFile* bmx::mxf_http_file_open_read(const string &url_str, uint32_t min_read_s
         http_file->size          = http_file_size;
         http_file->free_sys_data = free_http_file;
 
-        return http_file;
+        if (enable_seek) {
+            return http_file;
+        } else {
+            MXFFile *stream_file = 0;
+            BMX_CHECK(mxf_stream_file_wrap(http_file, true, &stream_file));
+            return stream_file;
+        }
     }
     catch (...)
     {
@@ -525,10 +532,11 @@ bool bmx::mxf_http_is_url(const string &url_str)
            url_str.compare(0, 8, "https://") == 0;
 }
 
-MXFFile* bmx::mxf_http_file_open_read(const string &url_str, uint32_t min_read_size)
+MXFFile* bmx::mxf_http_file_open_read(const string &url_str, uint32_t min_read_size, bool enable_seek)
 {
     (void)url_str;
     (void)min_read_size;
+    (void)enable_seek;
     BMX_EXCEPTION(("HTTP file access is not supported in this build"));
 }
 

--- a/src/mxf_helper/MXFFileFactory.cpp
+++ b/src/mxf_helper/MXFFileFactory.cpp
@@ -59,7 +59,7 @@ File* DefaultMXFFileFactory::OpenRead(string filename)
         BMX_CHECK(mxf_stdin_wrap_read(&mxf_file));
         return new File(mxf_file);
     } else if (mxf_http_is_url(filename)) {
-        return new File(mxf_http_file_open_read(filename, 64 * 1024), true);
+        return new File(mxf_http_file_open_read(filename, 1024 * 1024, true));
     } else {
         return File::openRead(filename);
     }

--- a/src/mxf_helper/MXFFileFactory.cpp
+++ b/src/mxf_helper/MXFFileFactory.cpp
@@ -59,7 +59,7 @@ File* DefaultMXFFileFactory::OpenRead(string filename)
         BMX_CHECK(mxf_stdin_wrap_read(&mxf_file));
         return new File(mxf_file);
     } else if (mxf_http_is_url(filename)) {
-        return new File(mxf_http_file_open_read(filename, 64 * 1024));
+        return new File(mxf_http_file_open_read(filename, 64 * 1024), true);
     } else {
         return File::openRead(filename);
     }


### PR DESCRIPTION
This PR adds the following:
*  a mxf2raw and bmxtranswrap `--http-disable-seek` option that disables seeking for an input file read over HTTP. The file is treated like a stream. In cases where the header partition contains complete metadata, or incomplete if acceptable, and no seeking is required, then using this option can be more efficient as it avoids indexing the partitions and essence positions.
* a mxf2raw and bmxtranswrap `--disable-indexing-files` option that is similar and has the same advantages as `--http-disable-seek` but it is not specific to HTTP and does try read the header metadata from the last partition as it may be more complete. It doesn't prevent the reader from seeking.
* extends the cases where `mxf2raw` will output file info (by default) to when there are no options that specifically require an action like reading essence or metadata. `mxf2raw --disable-indexing-files` will therefore now return the file info.

Addresses https://github.com/bbc/bmx/discussions/13#discussion-5220976