### PR TITLE
Write usage to stdout if not an error

### DIFF
--- a/apps/bmxparse/bmxparse.cpp
+++ b/apps/bmxparse/bmxparse.cpp
@@ -678,19 +678,23 @@ static bool parse_type_str(const char *type_str, InputType *input_type)
     return true;
 }
 
-static void usage(const char *cmd)
+static void usage(const char *cmd, bool error)
 {
-    fprintf(stderr, "%s\n", get_app_version_info(APP_NAME).c_str());
-    fprintf(stderr, "Text dump raw essence files using the bmx library's parser class\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s <<Options>> <type> <filename>\n", cmd);
-    fprintf(stderr, "    <type> is 'avc', 'dv', 'j2c', 'mjpeg', 'm2v', 'rdd36', 'vc2' or 'vc3'\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, " -h | --help           Show usage and exit\n");
-    fprintf(stderr, " -v | --version        Print version info to stderr\n");
-    fprintf(stderr, " -l <file>             Log filename. Default log to stderr\n");
-    fprintf(stderr, " --log-level <level>   Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
-    fprintf(stderr, " --single-field        Assume MJPEG single field encoding. Default is to parse field pairs\n");
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "%s\n", get_app_version_info(APP_NAME).c_str());
+    fprintf(output, "Text dump raw essence files using the bmx library's parser class\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s <<Options>> <type> <filename>\n", strip_path(cmd).c_str());
+    fprintf(output, "    <type> is 'avc', 'dv', 'j2c', 'mjpeg', 'm2v', 'rdd36', 'vc2' or 'vc3'\n");
+    fprintf(output, "Options:\n");
+    fprintf(output, " -h | --help           Show usage and exit\n");
+    fprintf(output, " -v | --version        Print version info to stderr\n");
+    fprintf(output, " -l <file>             Log filename. Default log to stderr\n");
+    fprintf(output, " --log-level <level>   Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
+    fprintf(output, " --single-field        Assume MJPEG single field encoding. Default is to parse field pairs\n");
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -703,7 +707,7 @@ int main(int argc, const char **argv)
     int cmdln_index;
 
     if (argc == 1) {
-        usage(argv[0]);
+        usage(argv[0], false);
         return 0;
     }
 
@@ -712,7 +716,7 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "--help") == 0 ||
             strcmp(argv[cmdln_index], "-h") == 0)
         {
-            usage(argv[0]);
+            usage(argv[0], false);
             return 0;
         }
         else if (strcmp(argv[cmdln_index], "--version") == 0 ||
@@ -728,7 +732,7 @@ int main(int argc, const char **argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage(argv[0], true);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -739,13 +743,13 @@ int main(int argc, const char **argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage(argv[0], true);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_log_level(argv[cmdln_index + 1], &log_level))
             {
-                usage(argv[0]);
+                usage(argv[0], true);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -761,22 +765,22 @@ int main(int argc, const char **argv)
         }
     }
     if (cmdln_index + 2 < argc) {
-        usage(argv[0]);
+        usage(argv[0], true);
         fprintf(stderr, "Unknown option '%s'\n", argv[cmdln_index]);
         return 1;
     }
     if (cmdln_index + 1 > argc) {
-        usage(argv[0]);
+        usage(argv[0], true);
         fprintf(stderr, "Missing <type> and <filename>\n");
         return 1;
     }
     if (cmdln_index + 2 > argc) {
-        usage(argv[0]);
+        usage(argv[0], true);
         fprintf(stderr, "Missing <filename>\n");
         return 1;
     }
     if (!parse_type_str(argv[cmdln_index], &input_type)) {
-        usage(argv[0]);
+        usage(argv[0], true);
         fprintf(stderr, "Invalid value '%s' for <type>\n", argv[cmdln_index]);
         return 1;
     }

--- a/apps/bmxtimecode.cpp
+++ b/apps/bmxtimecode.cpp
@@ -63,9 +63,9 @@ static bool parse_frame_rate(const char *rate_str, Rational *frame_rate)
     return false;
 }
 
-static void usage(const char *name)
+static void usage(const char *cmd)
 {
-    fprintf(stderr, "%s [--output tc-drop|tc-non-drop|count] [--rate (<n>|<n>/<d>)] (all|<timecode>|<frame count>)\n", name);
+    fprintf(stderr, "%s [--output tc-drop|tc-non-drop|count] [--rate (<n>|<n>/<d>)] (all|<timecode>|<frame count>)\n", strip_path(cmd).c_str());
 }
 
 int main(int argc, const char **argv)

--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -358,397 +358,404 @@ EssenceType process_assumed_essence_type(const MXFTrackInfo *input_track_info, E
     }
 }
 
-static void usage(const char *cmd)
+static void usage_ref(const char *cmd)
 {
     fprintf(stderr, "%s\n", get_app_version_info(APP_NAME).c_str());
-    fprintf(stderr, "Re-wrap from one MXF file to another MXF file\n");
+    fprintf(stderr, "Run '%s -h' to show detailed commandline usage.\n", strip_path(cmd).c_str());
     fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s <<Options>> [<<Input Options>> <mxf input>]+\n", cmd);
-    fprintf(stderr, "   Use <mxf input> '-' for standard input\n");
-    fprintf(stderr, "Options (* means option is required):\n");
-    fprintf(stderr, "  -h | --help             Show usage and exit\n");
-    fprintf(stderr, "  -v | --version          Print version info\n");
-    fprintf(stderr, "  -p                      Print progress percentage to stdout\n");
-    fprintf(stderr, "  -l <file>               Log filename. Default log to stderr/stdout\n");
-    fprintf(stderr, " --log-level <level>      Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
-    fprintf(stderr, "  -t <type>               Clip type: as02, as11op1a, as11d10, as11rdd9, op1a, avid, d10, rdd9, as10, wave, imf. Default is op1a\n");
-    fprintf(stderr, "* -o <name>               as02: <name> is a bundle name\n");
-    fprintf(stderr, "                          as11op1a/as11d10/op1a/d10/rdd9/as10/wave: <name> is a filename or filename pattern (see Notes at the end)\n");
-    fprintf(stderr, "                          avid: <name> is a filename prefix\n");
-    fprintf(stderr, "  --ess-type-names <names>  A comma separated list of 4 names for video, audio, data or mixed essence types\n");
-    fprintf(stderr, "                            The names can be used to replace {type} in output filename patterns\n");
-    fprintf(stderr, "                            The default names are: video,audio,data,mixed\n");
-    fprintf(stderr, "  --prod-info <cname>\n");
-    fprintf(stderr, "              <pname>\n");
-    fprintf(stderr, "              <ver>\n");
-    fprintf(stderr, "              <verstr>\n");
-    fprintf(stderr, "              <uid>\n");
-    fprintf(stderr, "                          Set the product info in the MXF Identification set\n");
-    fprintf(stderr, "                          <cname> is a string and is the Company Name property\n");
-    fprintf(stderr, "                          <pname> is a string and is the Product Name property\n");
-    fprintf(stderr, "                          <ver> has format '<major>.<minor>.<patch>.<build>.<release>' and is the Product Version property. Set to '0.0.0.0.0' to omit it\n");
-    fprintf(stderr, "                          <verstr> is a string and is the Version String property\n");
-    fprintf(stderr, "                          <uid> is a UUID (see Notes at the end) and is the Product UID property\n");
-    fprintf(stderr, "  --create-date <tstamp>  Set the creation date in the MXF Identification set. Default is 'now'\n");
-    fprintf(stderr, "  --input-file-md5        Calculate an MD5 checksum of the input file\n");
-    fprintf(stderr, "  -y <hh:mm:sscff>        Override input start timecode. Default 00:00:00:00\n");
-    fprintf(stderr, "                          The c character in the pattern should be ':' for non-drop frame; any other character indicates drop frame\n");
-    fprintf(stderr, "  --mtc                   Check first and use the input material package start timecode if present\n");
-    fprintf(stderr, "  --fstc                  Check first and use the file source package timecode if present\n");
-    fprintf(stderr, "  --pstc                  Check first and use the physical source package timecode if present\n");
-    fprintf(stderr, "  --tc-rate <rate>        Start timecode rate to use when input is audio only\n");
-    fprintf(stderr, "                          The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
-    fprintf(stderr, "  --clip <name>           Set the clip name\n");
-    fprintf(stderr, "  --start <count>         Set the start in input edit rate units. Default is 0\n");
-    fprintf(stderr, "  --dur <count>           Set the duration in input edit rate units. Default is minimum input duration\n");
-    fprintf(stderr, "  --check-end             Check at the start that the last (start + duration - 1) edit unit can be read\n");
-    fprintf(stderr, "  --check-end-tolerance <frame> Allow output duration shorter than input declared duration\n");
-    fprintf(stderr, "  --check-complete        Check that the input file structure can be read and is complete\n");
-    fprintf(stderr, "  --group                 Use the group reader instead of the sequence reader\n");
-    fprintf(stderr, "                          Use this option if the files have different material packages\n");
-    fprintf(stderr, "                          but actually belong to the same virtual package / group\n");
-    fprintf(stderr, "  --no-reorder            Don't attempt to order the inputs in a sequence\n");
-    fprintf(stderr, "                          Use this option for files with broken timecode\n");
-    fprintf(stderr, "  --rt <factor>           Transwrap at realtime rate x <factor>, where <factor> is a floating point value\n");
-    fprintf(stderr, "                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
-    fprintf(stderr, "  --gf                    Support growing files. Retry reading a frame when it fails\n");
-    fprintf(stderr, "  --gf-retries <max>      Set the maximum times to retry reading a frame. The default is %u.\n", DEFAULT_GF_RETRIES);
-    fprintf(stderr, "  --gf-delay <sec>        Set the delay (in seconds) between a failure to read and a retry. The default is %f.\n", DEFAULT_GF_RETRY_DELAY);
-    fprintf(stderr, "  --gf-rate <factor>      Limit the read rate to realtime rate x <factor> after a read failure. The default is %f\n", DEFAULT_GF_RATE_AFTER_FAIL);
-    fprintf(stderr, "                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
-    fprintf(stderr, " --disable-indexing-file   Use this option to stop the reader creating an index of the partitions and essence positions in the file up front\n");
-    fprintf(stderr, "                           This option can be used to avoid indexing files containing many partitions\n");
+}
+
+static void usage(const char *cmd)
+{
+    printf("%s\n", get_app_version_info(APP_NAME).c_str());
+    printf("Re-wrap from one MXF file to another MXF file\n");
+    printf("\n");
+    printf("Usage: %s <<Options>> [<<Input Options>> <mxf input>]+\n", strip_path(cmd).c_str());
+    printf("   Use <mxf input> '-' for standard input\n");
+    printf("Options (* means option is required):\n");
+    printf("  -h | --help             Show usage and exit\n");
+    printf("  -v | --version          Print version info\n");
+    printf("  -p                      Print progress percentage to stdout\n");
+    printf("  -l <file>               Log filename. Default log to stderr/stdout\n");
+    printf(" --log-level <level>      Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
+    printf("  -t <type>               Clip type: as02, as11op1a, as11d10, as11rdd9, op1a, avid, d10, rdd9, as10, wave, imf. Default is op1a\n");
+    printf("* -o <name>               as02: <name> is a bundle name\n");
+    printf("                          as11op1a/as11d10/op1a/d10/rdd9/as10/wave: <name> is a filename or filename pattern (see Notes at the end)\n");
+    printf("                          avid: <name> is a filename prefix\n");
+    printf("  --ess-type-names <names>  A comma separated list of 4 names for video, audio, data or mixed essence types\n");
+    printf("                            The names can be used to replace {type} in output filename patterns\n");
+    printf("                            The default names are: video,audio,data,mixed\n");
+    printf("  --prod-info <cname>\n");
+    printf("              <pname>\n");
+    printf("              <ver>\n");
+    printf("              <verstr>\n");
+    printf("              <uid>\n");
+    printf("                          Set the product info in the MXF Identification set\n");
+    printf("                          <cname> is a string and is the Company Name property\n");
+    printf("                          <pname> is a string and is the Product Name property\n");
+    printf("                          <ver> has format '<major>.<minor>.<patch>.<build>.<release>' and is the Product Version property. Set to '0.0.0.0.0' to omit it\n");
+    printf("                          <verstr> is a string and is the Version String property\n");
+    printf("                          <uid> is a UUID (see Notes at the end) and is the Product UID property\n");
+    printf("  --create-date <tstamp>  Set the creation date in the MXF Identification set. Default is 'now'\n");
+    printf("  --input-file-md5        Calculate an MD5 checksum of the input file\n");
+    printf("  -y <hh:mm:sscff>        Override input start timecode. Default 00:00:00:00\n");
+    printf("                          The c character in the pattern should be ':' for non-drop frame; any other character indicates drop frame\n");
+    printf("  --mtc                   Check first and use the input material package start timecode if present\n");
+    printf("  --fstc                  Check first and use the file source package timecode if present\n");
+    printf("  --pstc                  Check first and use the physical source package timecode if present\n");
+    printf("  --tc-rate <rate>        Start timecode rate to use when input is audio only\n");
+    printf("                          The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
+    printf("  --clip <name>           Set the clip name\n");
+    printf("  --start <count>         Set the start in input edit rate units. Default is 0\n");
+    printf("  --dur <count>           Set the duration in input edit rate units. Default is minimum input duration\n");
+    printf("  --check-end             Check at the start that the last (start + duration - 1) edit unit can be read\n");
+    printf("  --check-end-tolerance <frame> Allow output duration shorter than input declared duration\n");
+    printf("  --check-complete        Check that the input file structure can be read and is complete\n");
+    printf("  --group                 Use the group reader instead of the sequence reader\n");
+    printf("                          Use this option if the files have different material packages\n");
+    printf("                          but actually belong to the same virtual package / group\n");
+    printf("  --no-reorder            Don't attempt to order the inputs in a sequence\n");
+    printf("                          Use this option for files with broken timecode\n");
+    printf("  --rt <factor>           Transwrap at realtime rate x <factor>, where <factor> is a floating point value\n");
+    printf("                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
+    printf("  --gf                    Support growing files. Retry reading a frame when it fails\n");
+    printf("  --gf-retries <max>      Set the maximum times to retry reading a frame. The default is %u.\n", DEFAULT_GF_RETRIES);
+    printf("  --gf-delay <sec>        Set the delay (in seconds) between a failure to read and a retry. The default is %f.\n", DEFAULT_GF_RETRY_DELAY);
+    printf("  --gf-rate <factor>      Limit the read rate to realtime rate x <factor> after a read failure. The default is %f\n", DEFAULT_GF_RATE_AFTER_FAIL);
+    printf("                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
+    printf(" --disable-indexing-file   Use this option to stop the reader creating an index of the partitions and essence positions in the file up front\n");
+    printf("                           This option can be used to avoid indexing files containing many partitions\n");
     if (mxf_http_is_supported()) {
-        fprintf(stderr, " --http-min-read <bytes>\n");
-        fprintf(stderr, "                          Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
-        fprintf(stderr, " --http-disable-seek      Disable seeking when reading file over HTTP\n");
+        printf(" --http-min-read <bytes>\n");
+        printf("                          Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
+        printf(" --http-disable-seek      Disable seeking when reading file over HTTP\n");
     }
-    fprintf(stderr, "  --no-precharge          Don't output clip/track with precharge. Adjust the start position and duration instead\n");
-    fprintf(stderr, "  --no-rollout            Don't output clip/track with rollout. Adjust the duration instead\n");
-    fprintf(stderr, "  --rw-intl               Interleave input reads with output writes\n");
-    fprintf(stderr, "  --rw-intl-size          The interleave size. Default is %u\n", DEFAULT_RW_INTL_SIZE);
-    fprintf(stderr, "                          Value must be a multiple of the system page size, %u\n", mxf_get_system_page_size());
+    printf("  --no-precharge          Don't output clip/track with precharge. Adjust the start position and duration instead\n");
+    printf("  --no-rollout            Don't output clip/track with rollout. Adjust the duration instead\n");
+    printf("  --rw-intl               Interleave input reads with output writes\n");
+    printf("  --rw-intl-size          The interleave size. Default is %u\n", DEFAULT_RW_INTL_SIZE);
+    printf("                          Value must be a multiple of the system page size, %u\n", mxf_get_system_page_size());
 #if defined(_WIN32)
-    fprintf(stderr, "  --seq-scan              Set the sequential scan hint for optimizing file caching whilst reading\n");
+    printf("  --seq-scan              Set the sequential scan hint for optimizing file caching whilst reading\n");
 #if !defined(__MINGW32__)
-    fprintf(stderr, "  --mmap-file             Use memory-mapped file I/O for the MXF files\n");
-    fprintf(stderr, "                          Note: this may reduce file I/O performance and was found to be slower over network drives\n");
+    printf("  --mmap-file             Use memory-mapped file I/O for the MXF files\n");
+    printf("                          Note: this may reduce file I/O performance and was found to be slower over network drives\n");
 #endif
 #endif
-    fprintf(stderr, "  --avcihead <format> <file> <offset>\n");
-    fprintf(stderr, "                          Default AVC-Intra sequence header data (512 bytes) to use when the input file does not have it\n");
-    fprintf(stderr, "                          <format> is a comma separated list of one or more of the following integer values:\n");
+    printf("  --avcihead <format> <file> <offset>\n");
+    printf("                          Default AVC-Intra sequence header data (512 bytes) to use when the input file does not have it\n");
+    printf("                          <format> is a comma separated list of one or more of the following integer values:\n");
     size_t i;
     for (i = 0; i < get_num_avci_header_formats(); i++)
-        fprintf(stderr, "                              %2" PRIszt ": %s\n", i, get_avci_header_format_string(i));
-    fprintf(stderr, "                          or set <format> to 'all' for all formats listed above\n");
-    fprintf(stderr, "                          The 512 bytes are extracted from <file> starting at <offset> bytes\n");
-    fprintf(stderr, "                          and incrementing 512 bytes for each format in the list\n");
-    fprintf(stderr, "  --ps-avcihead           Panasonic AVC-Intra sequence header data for Panasonic-compatible files that don't include the header data\n");
-    fprintf(stderr, "                          These formats are supported:\n");
+        printf("                              %2" PRIszt ": %s\n", i, get_avci_header_format_string(i));
+    printf("                          or set <format> to 'all' for all formats listed above\n");
+    printf("                          The 512 bytes are extracted from <file> starting at <offset> bytes\n");
+    printf("                          and incrementing 512 bytes for each format in the list\n");
+    printf("  --ps-avcihead           Panasonic AVC-Intra sequence header data for Panasonic-compatible files that don't include the header data\n");
+    printf("                          These formats are supported:\n");
     for (i = 0; i < get_num_ps_avci_header_formats(); i++) {
         if (i == 0)
-            fprintf(stderr, "                              ");
+            printf("                              ");
         else if (i % 4 == 0)
-            fprintf(stderr, ",\n                              ");
+            printf(",\n                              ");
         else
-            fprintf(stderr, ", ");
-        fprintf(stderr, "%s", get_ps_avci_header_format_string(i));
+            printf(", ");
+        printf("%s", get_ps_avci_header_format_string(i));
     }
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  -a <n:d>                Override or set the image aspect ratio\n");
-    fprintf(stderr, "  --bsar                  Set image aspect ratio in video bitstream. Currently supports D-10 essence types only\n");
-    fprintf(stderr, "  --vc2-mode <mode>       Set the mode that determines how the VC-2 data is wrapped\n");
-    fprintf(stderr, "                          <mode> is one of the following integer values:\n");
-    fprintf(stderr, "                            0: Passthrough input, but add a sequence header if not present, remove duplicate/redundant sequence headers\n");
-    fprintf(stderr, "                               and fix any incorrect parse info offsets and picture numbers\n");
-    fprintf(stderr, "                            1: (default) Same as 0, but remove auxiliary and padding data units and complete the sequence in each frame\n");
-    fprintf(stderr, "  --locked <bool>         Override or set flag indicating whether the number of audio samples is locked to the video. Either true or false\n");
-    fprintf(stderr, "  --audio-ref <level>     Override or set audio reference level, number of dBm for 0VU\n");
-    fprintf(stderr, "  --dial-norm <value>     Override or set gain to be applied to normalize perceived loudness of the clip\n");
-    fprintf(stderr, "  --ref-image-edit-rate <rate>     Override or set the Reference Image Edit Rate\n");
-    fprintf(stderr, "                                   The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
-    fprintf(stderr, "  --ref-audio-align-level <value>  Override or set the Reference Audio Alignment Level\n");
-    fprintf(stderr, "  --signal-std  <value>   Override or set the video signal standard. The <value> is one of the following:\n");
-    fprintf(stderr, "                              'none', 'bt601', 'bt1358', 'st347', 'st274', 'st296', 'st349', 'st428'\n");
-    fprintf(stderr, "  --frame-layout <value>  Override or set the video frame layout. The <value> is one of the following:\n");
-    fprintf(stderr, "                              'fullframe', 'separatefield', 'singlefield', 'mixedfield', 'segmentedframe'\n");
-    fprintf(stderr, "  --field-dom <value>     Override or set which field is first in temporal order. The <value> is 1 or 2\n");
-    fprintf(stderr, "  --transfer-ch <value>   Override or set the transfer characteristic label\n");
-    fprintf(stderr, "                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
-    fprintf(stderr, "                              'bt470', 'bt709', 'st240', 'st274', 'bt1361', 'linear', 'dcdm',\n");
-    fprintf(stderr, "                              'iec61966', 'bt2020', 'st2084', 'hlg'\n");
-    fprintf(stderr, "  --coding-eq <value>     Override or set the coding equations label\n");
-    fprintf(stderr, "                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
-    fprintf(stderr, "                              'bt601', 'bt709', 'st240', 'ycgco', 'gbr', 'bt2020'\n");
-    fprintf(stderr, "  --color-prim <value>    Override or set the color primaries label\n");
-    fprintf(stderr, "                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
-    fprintf(stderr, "                              'st170', 'bt470', 'bt709', 'bt2020', 'dcdm', 'p3'\n");
-    fprintf(stderr, "  --color-siting <value>  Override or set the color siting. The <value> is one of the following:\n");
-    fprintf(stderr, "                              'cositing', 'horizmp', '3tap', 'quincunx', 'bt601', 'linealt', 'vertmp', 'unknown'\n");
-    fprintf(stderr, "                              (Note that 'bt601' is deprecated in SMPTE ST 377-1. Use 'cositing' instead)\n");
-    fprintf(stderr, "  --black-level <value>   Override or set the black reference level\n");
-    fprintf(stderr, "  --white-level <value>   Override or set the white reference level\n");
-    fprintf(stderr, "  --color-range <value>   Override or set the color range\n");
-    fprintf(stderr, "  --comp-max-ref <value>  Override or set the RGBA component maximum reference level\n");
-    fprintf(stderr, "  --comp-min-ref <value>  Override or set the RGBA component minimum reference level\n");
-    fprintf(stderr, "  --scan-dir <value>      Override or set the RGBA scanning direction\n");
-    fprintf(stderr, "  --display-primaries <value>    Override or set the mastering display primaries.\n");
-    fprintf(stderr, "                                 The <value> is an array of 6 unsigned integers separated by a ','.\n");
-    fprintf(stderr, "  --display-white-point <value>  Override or set the mastering display white point chromaticity.\n");
-    fprintf(stderr, "                                 The <value> is an array of 2 unsigned integers separated by a ','.\n");
-    fprintf(stderr, "  --display-max-luma <value>     Override or set the mastering display maximum luminance.\n");
-    fprintf(stderr, "  --display-min-luma <value>     Override or set the mastering display minimum luminance.\n");
-    fprintf(stderr, "  --rdd36-opaque              Override and treat RDD-36 4444 or 4444 XQ as opaque by omitting the Alpha Sample Depth property\n");
-    fprintf(stderr, "  --rdd36-comp-depth <value>  Override of set component depth for RDD-36. Defaults to 10 if not present in input file\n");
-    fprintf(stderr, "  --active-width          Override or set the Active Width of the active area rectangle\n");
-    fprintf(stderr, "  --active-height         Override or set the Active Height of the active area rectangle\n");
-    fprintf(stderr, "  --active-x-offset       Override or set the Active X Offset of the active area rectangle\n");
-    fprintf(stderr, "  --active-y-offset       Override or set the Active Y Offset of the active area rectangle\n");
-    fprintf(stderr, "  --display-f2-offset     Override or set the default Display F2 Offset if it is not extracted from the essence\n");
-    fprintf(stderr, "  --center-cut-4-3        Override or add the Alternative Center Cut 4:3\n");
-    fprintf(stderr, "  --center-cut-14-9       Override or add the Alternative Center Cut 14:9\n");
-    fprintf(stderr, "  --ignore-input-desc     Don't use input MXF file descriptor properties to fill in missing information\n");
-    fprintf(stderr, "  --track-map <expr>      Map input audio channels to output tracks\n");
-    fprintf(stderr, "                          The default is 'mono', except if --clip-wrap option is set for op1a it is 'singlemca'\n");
-    fprintf(stderr, "                          See below for details of the <expr> format\n");
-    fprintf(stderr, "  --dump-track-map        Dump the output audio track map to stderr.\n");
-    fprintf(stderr, "                          The dumps consists of a list output tracks, where each output track channel\n");
-    fprintf(stderr, "                          is shown as '<output track channel> <- <input channel>\n");
-    fprintf(stderr, "  --dump-track-map-exit   Same as --dump-track-map, but exit immediately afterwards\n");
-    fprintf(stderr, "  --assume-d10-30         Assume a generic MPEG video elementary stream is actually D-10 30\n");
-    fprintf(stderr, "  --assume-d10-40         Assume a generic MPEG video elementary stream is actually D-10 40\n");
-    fprintf(stderr, "  --assume-d10-50         Assume a generic MPEG video elementary stream is actually D-10 50\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/as11rdd9/op1a/rdd9/d10:\n");
-    fprintf(stderr, "    --head-fill <bytes>     Reserve minimum <bytes> at the end of the header metadata using a KLV Fill\n");
-    fprintf(stderr, "                            Add a 'K' suffix for kibibytes and 'M' for mibibytes\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02:\n");
-    fprintf(stderr, "    --mic-type <type>       Media integrity check type: 'md5' or 'none'. Default 'md5'\n");
-    fprintf(stderr, "    --mic-file              Calculate checksum for entire essence component file. Default is essence only\n");
-    fprintf(stderr, "    --shim-name <name>      Set ShimName element value in shim.xml file to <name>. Default is '%s'\n", DEFAULT_SHIM_NAME);
-    fprintf(stderr, "    --shim-id <id>          Set ShimID element value in shim.xml file to <id>. Default is '%s'\n", DEFAULT_SHIM_ID);
-    fprintf(stderr, "    --shim-annot <str>      Set AnnotationText element value in shim.xml file to <str>. Default is '%s'\n", DEFAULT_SHIM_ANNOTATION);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02/as11op1a/op1a/rdd9/as10:\n");
-    fprintf(stderr, "    --part <interval>       Video essence partition interval in frames in input edit rate units, or (floating point) seconds with 's' suffix. Default single partition\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/as11rdd9:\n");
-    fprintf(stderr, "    --dm <fwork> <name> <value>    Set descriptive framework property. <fwork> is 'as11' or 'dpp'\n");
-    fprintf(stderr, "    --dm-file <fwork> <name>       Parse and set descriptive framework properties from text file <name>. <fwork> is 'as11' or 'dpp'\n");
-    fprintf(stderr, "    --seg <name>                   Parse and set segmentation data from text file <name>\n");
-    fprintf(stderr, "    --pass-dm                      Copy descriptive metadata from the input file. The metadata can be overidden by other options\n");
-    fprintf(stderr, "    --norm-pass-dm                 Same as --pass-dm, but also normalise strings to always have a null terminator. This is a workaround for products that fail to handle zero size string properties.\n");
-    fprintf(stderr, "    --spec-id <id>                 Set the AS-11 specification identifier labels associated with <id>\n");
-    fprintf(stderr, "                                   The <id> is one of the following:\n");
-    fprintf(stderr, "                                       as11-x1 : AMWA AS-11 X1, delivery of finished UHD programs to Digital Production Partnership (DPP) broadcasters\n");
-    fprintf(stderr, "                                       as11-x2 : AMWA AS-11 X2, delivery of finished HD AVC Intra programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x3 : AMWA AS-11 X3, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x4 : AMWA AS-11 X4, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x5 : AMWA AS-11 X5, delivery of finished UHD TV Commericals and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
-    fprintf(stderr, "                                       as11-x6 : AMWA AS-11 X6, delivery of finished HD TV Commercials and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
-    fprintf(stderr, "                                       as11-x7 : AMWA AS-11 X7, delivery of finished SD D10 programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x8 : AMWA AS-11 X8, delivery of finished HD (MPEG-2) programs to North American Broadcasters Association (NABA) broadcasters\n");
-    fprintf(stderr, "                                       as11-x9 : AMWA AS-11 X9, delivery of finished HD TV Programmes (AVC) to North American Broadcasters Association (NABA) broadcasters\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02/as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
-    fprintf(stderr, "    --afd <value>           Active Format Descriptor 4-bit code from table 1 in SMPTE ST 2016-1. Default is input file's value or not set\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
-    fprintf(stderr, "    --single-pass           Write file in a single pass\n");
-    fprintf(stderr, "                            Header and body partitions will be incomplete for as11op1a/op1a if the number if essence container bytes per edit unit is variable\n");
-    fprintf(stderr, "    --file-md5              Calculate an MD5 checksum of the output file. This requires writing in a single pass (--single-pass is assumed)\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/op1a:\n");
-    fprintf(stderr, "    --pass-anc <filter>     Pass through ST 436 ANC data tracks\n");
-    fprintf(stderr, "                            <filter> is a comma separated list of ANC data types to pass through\n");
-    fprintf(stderr, "                            The following ANC data types are supported in <filter>:\n");
-    fprintf(stderr, "                                all      : pass through all ANC data\n");
-    fprintf(stderr, "                                st2020   : SMPTE ST 2020 / RDD 6 audio metadata\n");
-    fprintf(stderr, "                                st2016   : SMPTE ST 2016-3/ AFD, bar and pan-scan data\n");
-    fprintf(stderr, "                                sdp      : SMPTE RDD 8 / OP-47 Subtitling Distribution Packet data\n");
-    fprintf(stderr, "                                st12     : SMPTE ST 12 Ancillary timecode\n");
-    fprintf(stderr, "                                st334    : SMPTE ST 334-1 EIA 708B, EIA 608 and data broadcast (DTV)\n");
-    fprintf(stderr, "    --pass-vbi              Pass through ST 436 VBI data tracks\n");
-    fprintf(stderr, "    --st436-mf <count>      Set the <count> of frames to examine for ST 436 ANC/VBI manifest info. Default is %u\n", DEFAULT_ST436_MANIFEST_COUNT);
-    fprintf(stderr, "                            The manifest is used at the start to determine whether an output ANC data track is created\n");
-    fprintf(stderr, "                            Set <count> to 0 to always create an ANC data track if the input has one\n");
-    fprintf(stderr, "    --anc-const <size>      Use to indicate that the ST 436 ANC frame element data, excl. key and length, has a constant <size>. A variable size is assumed by default\n");
-    fprintf(stderr, "    --anc-max <size>        Use to indicate that the ST 436 ANC frame element data, excl. key and length, has a maximum <size>. A variable size is assumed by default\n");
-    fprintf(stderr, "    --st2020-max            The ST 436 ANC maximum frame element data size for ST 2020 only is calculated from the extracted manifest. Option '--pass-anc st2020' is required.\n");
-    fprintf(stderr, "    --vbi-const <size>      Use to indicate that the ST 436 VBI frame element data, excl. key and length, has a constant <size>. A variable size is assumed by default\n");
-    fprintf(stderr, "    --vbi-max <size>        Use to indicate that the ST 436 VBI frame element data, excl. key and length, has a maximum <size>. A variable size is assumed by default\n");
-    fprintf(stderr, "    --rdd6 <file>           Add ST 436 ANC data track containing 'static' RDD-6 audio metadata from XML <file>\n");
-    fprintf(stderr, "                            The timecode fields are ignored, i.e. they are set to 'undefined' values in the RDD-6 metadata stream\n");
-    fprintf(stderr, "    --rdd6-lines <lines>    A single or pair of line numbers, using ',' as the separator, for carriage of the RDD-6 ANC data. The default is a pair of numbers, '%u,%u'\n", DEFAULT_RDD6_LINES[0], DEFAULT_RDD6_LINES[1]);
-    fprintf(stderr, "    --rdd6-sdid <sdid>      The SDID value indicating the first audio channel pair associated with the RDD-6 data. Default is %u\n", DEFAULT_RDD6_SDID);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/rdd9/d10:\n");
-    fprintf(stderr, "    --xml-scheme-id <id>    Set the XML payload scheme identifier associated with the following --embed-xml option.\n");
-    fprintf(stderr, "                            The <id> is one of the following:\n");
-    fprintf(stderr, "                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
-    fprintf(stderr, "                                * a UUID, formatted as a 'urn:uuid:...'or as 32 hexadecimal characters using a '.' or '-' seperator,\n");
-    fprintf(stderr, "                                * 'as11', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.04010000\n");
-    fprintf(stderr, "                            A default BMX scheme identifier is used if this option is not provided\n");
-    fprintf(stderr, "    --xml-lang <tag>        Set the RFC 5646 language tag associated with the the following --embed-xml option.\n");
-    fprintf(stderr, "                            Defaults to the xml:lang attribute in the root element or empty string if not present\n");
-    fprintf(stderr, "    --embed-xml <filename>  Embed the XML from <filename> using the approach specified in SMPTE RP 2057\n");
-    fprintf(stderr, "                            If the XML size is less than 64KB and uses UTF-8 or UTF-16 encoding (declared in\n");
-    fprintf(stderr, "                            the XML prolog) then the XML data is included in the header metadata. Otherwise\n");
-    fprintf(stderr, "                            a Generic Stream partition is used to hold the XML data.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a:\n");
-    fprintf(stderr, "    --no-tc-track           Don't create a timecode track in either the material or file source package\n");
-    fprintf(stderr, "    --min-part              Only use a header and footer MXF file partition. Use this for applications that don't support\n");
-    fprintf(stderr, "                            separate partitions for header metadata, index tables, essence container data and footer\n");
-    fprintf(stderr, "    --body-part             Create separate body partitions for essence data\n");
-    fprintf(stderr, "                            and don't create separate body partitions for index table segments\n");
-    fprintf(stderr, "    --repeat-index          Repeat the index table segments in the footer partition\n");
-    fprintf(stderr, "    --clip-wrap             Use clip wrapping for a single sound track\n");
-    fprintf(stderr, "    --mp-track-num          Use the material package track number property to define a track order. By default the track number is set to 0\n");
-    fprintf(stderr, "    --aes-3                 Use AES-3 audio mapping\n");
-    fprintf(stderr, "    --kag-size-512          Set KAG size to 512, instead of 1\n");
-    fprintf(stderr, "    --system-item           Add system item\n");
-    fprintf(stderr, "    --primary-package       Set the header metadata set primary package property to the top-level file source package\n");
-    fprintf(stderr, "    --index-follows         The index partition follows the essence partition, even when it is CBE essence\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/rdd9:\n");
-    fprintf(stderr, "    --ard-zdf-hdf           Use the ARD ZDF HDF profile\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/d10:\n");
-    fprintf(stderr, "    --cbe-index-duration-0  Use duration=0 if index table is CBE\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as10:\n");
-    fprintf(stderr, "    --shim-name <name>      Shim name for AS10 (used for setting 'ShimName' metadata and setting video/sound parameters' checks)\n");
-    fprintf(stderr, "                            list of known shims: %s\n", get_as10_shim_names().c_str());
-    fprintf(stderr, "    --dm-file as10 <name>   Parse and set descriptive framework properties from text file <name>\n");
-    fprintf(stderr, "                            N.B. 'ShimName' is the only mandatary property of AS10 metadata set\n");
-    fprintf(stderr, "    --dm as10 <name> <value>    Set descriptive framework property\n");
-    fprintf(stderr, "    --pass-dm               Copy descriptive metadata from the input file. The metadata can be overidden by other options\n");
-    fprintf(stderr, "    --mpeg-checks [<name>]  Enable AS-10 compliancy checks. The file <name> is optional and contains expected descriptor values\n");
-    fprintf(stderr, "    --loose-checks          Don't stop processing on detected compliancy violations\n");
-    fprintf(stderr, "    --print-checks          Print default values of mpeg descriptors and report on descriptors either found in mpeg headers or copied from mxf headers\n");
-    fprintf(stderr, "    --max-same-warnings <value>  Max same violations warnings logged, default 3\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11d10/d10:\n");
-    fprintf(stderr, "    --d10-mute <flags>      Indicate using a string of 8 '0' or '1' which sound channels should be muted. The lsb is the rightmost digit\n");
-    fprintf(stderr, "    --d10-invalid <flags>   Indicate using a string of 8 '0' or '1' which sound channels should be flagged invalid. The lsb is the rightmost digit\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
-    fprintf(stderr, "    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
-    fprintf(stderr, "    --fp-uid <umid>         Set the File Package UID. Autogenerated by default\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  avid:\n");
-    fprintf(stderr, "    --project <name>        Set the Avid project name\n");
-    fprintf(stderr, "    --tape <name>           Source tape name\n");
-    fprintf(stderr, "    --import <name>         Source import name. <name> is one of the following:\n");
-    fprintf(stderr, "                              - a file URL starting with 'file://'\n");
-    fprintf(stderr, "                              - an absolute Windows (starts with '[A-Z]:') or *nix (starts with '/') filename\n");
-    fprintf(stderr, "                              - a relative filename, which will be converted to an absolute filename\n");
-    fprintf(stderr, "    --comment <string>      Add 'Comments' user comment to the MaterialPackage\n");
-    fprintf(stderr, "    --desc <string>         Add 'Descript' user comment to the MaterialPackage\n");
-    fprintf(stderr, "    --tag <name> <value>    Add <name> user comment to the MaterialPackage. Option can be used multiple times\n");
-    fprintf(stderr, "    --locator <position> <comment> <color>\n");
-    fprintf(stderr, "                            Add locator at <position> with <comment> and <color>\n");
-    fprintf(stderr, "                            <position> format is o?hh:mm:sscff, where the optional 'o' indicates it is an offset\n");
-    fprintf(stderr, "    --umid-type <type>      Set the UMID type that is generated for the Package UID properties.\n");
-    fprintf(stderr, "                            The default <type> is 'aafsdk'.\n");
-    fprintf(stderr, "                            The <type> is one of the following:\n");
-    fprintf(stderr, "                              uuid       : UUID generation method\n");
-    fprintf(stderr, "                              aafsdk     : same method as implemented in the AAF SDK\n");
-    fprintf(stderr, "                                           This type is required to be compatible with some older Avid product versions\n");
-    fprintf(stderr, "                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
-    fprintf(stderr, "                              old-aafsdk : same method as implemented in revision 1.47 of AAF/ref-impl/src/impl/AAFUtils.c in the AAF SDK\n");
-    fprintf(stderr, "                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
-    fprintf(stderr, "    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
-    fprintf(stderr, "    --mp-created <tstamp>   Set the Material Package creation date. Default is 'now'\n");
-    fprintf(stderr, "    --psp-uid <umid>        Set the tape/import Source Package UID\n");
-    fprintf(stderr, "                              tape: autogenerated by default\n");
-    fprintf(stderr, "                              import: single input Material Package UID or autogenerated by default\n");
-    fprintf(stderr, "    --psp-created <tstamp>  Set the tape/import Source Package creation date. Default is 'now'\n");
-    fprintf(stderr, "    --ess-marks             Convert XDCAM Essence Marks to locators\n");
-    fprintf(stderr, "    --allow-no-avci-head    Allow inputs with no AVCI header (512 bytes, sequence and picture parameter sets)\n");
-    fprintf(stderr, "    --avid-gf               Use the Avid growing file flavour\n");
-    fprintf(stderr, "    --avid-gf-dur <dur>     Set the duration which should be shown whilst the file is growing\n");
-    fprintf(stderr, "                            The default value is the output duration\n");
-    fprintf(stderr, "    --ignore-d10-aes3-flags   Ignore D10 AES3 audio validity flags and assume they are all valid\n");
-    fprintf(stderr, "                              This workarounds an issue with Avid transfer manager which sets channel flags 4 to 8 to invalid\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/avid:\n");
-    fprintf(stderr, "    --force-no-avci-head    Strip AVCI header (512 bytes, sequence and picture parameter sets) if present\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  wave:\n");
-    fprintf(stderr, "    --orig <name>           Set originator in the Wave bext chunk. Default '%s'\n", DEFAULT_BEXT_ORIGINATOR);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02/op1a/as11op1a:\n");
-    fprintf(stderr, "    --use-avc-subdesc       Use the AVC sub-descriptor rather than the MPEG video descriptor for AVC-Intra tracks\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/as11op1a/rdd9:\n");
-    fprintf(stderr, "    --audio-layout <label>  Set the Wave essence descriptor channel assignment label which identifies the audio layout mode in operation\n");
-    fprintf(stderr, "                            The <label> is one of the following:\n");
-    fprintf(stderr, "                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
-    fprintf(stderr, "                                * 'as11-mode-0', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02010000,\n");
-    fprintf(stderr, "                                * 'as11-mode-1', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02020000,\n");
-    fprintf(stderr, "                                * 'as11-mode-2', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02030000\n");
-    fprintf(stderr, "                                * 'imf', which corresponds to urn:smpte:ul:060e2b34.0401010d.04020210.04010000\n");
-    fprintf(stderr, "    --track-mca-labels <scheme> <file>  Insert audio labels defined in <file>. The 'as11' <scheme> will add an override and otherwise <scheme> is ignored\n");
-    fprintf(stderr, "                                        The format of <file> is described in bmx/docs/mca_labels_format.md\n");
-    fprintf(stderr, "                                        All tag symbols registered in the bmx code are available for use\n");
-    fprintf(stderr, "                                        The 'as11' <scheme> will change the label associated with the 'chVIN' tag symbol to use the 'Visually Impaired Narrative' tag name, i.e. without a '-'\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Input options:\n");
-    fprintf(stderr, "  --disable-tracks <tracks> A comma separated list of track indexes and/or ranges to disable.\n");
-    fprintf(stderr, "                            A track is identified by the index reported by mxf2raw\n");
-    fprintf(stderr, "                            A range of track indexes is specified as '<first>-<last>', e.g. 0-3\n");
-    fprintf(stderr, "  --disable-audio           Disable audio tracks\n");
-    fprintf(stderr, "  --disable-video           Disable video tracks\n");
-    fprintf(stderr, "  --disable-data            Disable data tracks\n");
-    fprintf(stderr, "\n\n");
-    fprintf(stderr, "Notes:\n");
-    fprintf(stderr, " - filename pattern: Clip types producing a single output file may use a filename pattern with variables that get substituted\n");
-    fprintf(stderr, "                     Pattern variables start with a '{' and end with a '}'. E.g. 'output_{type}_{fp_uuid}.mxf'\n");
-    fprintf(stderr, "                     The following variables are available:\n");
-    fprintf(stderr, "                       - {type}: Is replaced with the name for video, audio, data or mixed essence types\n");
-    fprintf(stderr, "                                 See the --ess-type-names option for the default names and use the option to change them\n");
-    fprintf(stderr, "                       - {mp_uuid}: The UUID material number in a material package UMID\n");
-    fprintf(stderr, "                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
-    fprintf(stderr, "                       - {mp_umid}: The material package UMID\n");
-    fprintf(stderr, "                       - {fp_uuid}: The UUID material number in a file source package UMID\n");
-    fprintf(stderr, "                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
-    fprintf(stderr, "                       - {fp_umid}: The file source package UMID\n");
-    fprintf(stderr, " - <umid> format is 64 hexadecimal characters and any '.' and '-' characters are ignored\n");
-    fprintf(stderr, " - <uuid> format is 32 hexadecimal characters and any '.' and '-' characters are ignored\n");
-    fprintf(stderr, " - <tstamp> format is YYYY-MM-DDThh:mm:ss:qm where qm is in units of 1/250th second\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " The track mapping <expr> format is one of the following:\n");
-    fprintf(stderr, "     'mono'     : each input audio channel is mapped to a single-channel output track\n");
-    fprintf(stderr, "     'stereo'   : input audio channels are paired to stereo-channel output tracks\n");
-    fprintf(stderr, "                  A silence channel is added to the last output track if the channel count is odd\n");
-    fprintf(stderr, "     'singlemca': all input audio channels are mapped to a single multi-channel output track\n");
-    fprintf(stderr, "     <pattern>  : a pattern defining how input channels map to output track channels - see below\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " The track mapping <pattern> specifies how input audio channels are mapped to output track channels\n");
-    fprintf(stderr, " A <pattern> consists of a list of <group>s separated by a ';'.\n");
-    fprintf(stderr, " A <group> starts with an optional 'm', followed by a list of <element> separated by a ','.\n");
-    fprintf(stderr, "   An 'm' indicates that each channel in the <group> is mapped to separate single-channel output track.\n");
-    fprintf(stderr, "   If an 'm' is not present then the channels are mapped to a single output track.\n");
-    fprintf(stderr, " A <element> is either a <channel>, <range>, <silence> or <remainder>.\n");
-    fprintf(stderr, " A <channel> is an input channel number starting from 0.\n");
-    fprintf(stderr, "   The input channel number is the number derived from the input track order reported by mxf2raw for the\n");
-    fprintf(stderr, "   input files in the same order and including any --disable input options. Each channel in a track\n");
-    fprintf(stderr, "   contributes 1 to the overall channel number.\n");
-    fprintf(stderr, " A <range> is 2 <channel>s separated by a '-' and includes all channels starting with the first number\n");
-    fprintf(stderr, "   and ending with the last number.\n");
-    fprintf(stderr, " A <silence> is 's' followed by a <count> and results in <count> silence channels added to the output track.\n");
-    fprintf(stderr, " A <remainder> is 'x', and results in all remaining channels being added to the output track.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Here are some <pattern> examples:\n");
-    fprintf(stderr, "    'mx'     : equivalent to 'mono'\n");
-    fprintf(stderr, "    '0,1;x'  : the first 2 channels mapped to a stereo output track and all remaining channels mapped\n");
-    fprintf(stderr, "               to a single multi-channel track\n");
-    fprintf(stderr, "    '2-7;0,1': 6 channel output track followed by a 2 channel output track\n");
-    fprintf(stderr, "    '0,1,s2' : 2 input channels plus 2 silence channels mapped to a single output track\n");
+    printf("\n");
+    printf("  -a <n:d>                Override or set the image aspect ratio\n");
+    printf("  --bsar                  Set image aspect ratio in video bitstream. Currently supports D-10 essence types only\n");
+    printf("  --vc2-mode <mode>       Set the mode that determines how the VC-2 data is wrapped\n");
+    printf("                          <mode> is one of the following integer values:\n");
+    printf("                            0: Passthrough input, but add a sequence header if not present, remove duplicate/redundant sequence headers\n");
+    printf("                               and fix any incorrect parse info offsets and picture numbers\n");
+    printf("                            1: (default) Same as 0, but remove auxiliary and padding data units and complete the sequence in each frame\n");
+    printf("  --locked <bool>         Override or set flag indicating whether the number of audio samples is locked to the video. Either true or false\n");
+    printf("  --audio-ref <level>     Override or set audio reference level, number of dBm for 0VU\n");
+    printf("  --dial-norm <value>     Override or set gain to be applied to normalize perceived loudness of the clip\n");
+    printf("  --ref-image-edit-rate <rate>     Override or set the Reference Image Edit Rate\n");
+    printf("                                   The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
+    printf("  --ref-audio-align-level <value>  Override or set the Reference Audio Alignment Level\n");
+    printf("  --signal-std  <value>   Override or set the video signal standard. The <value> is one of the following:\n");
+    printf("                              'none', 'bt601', 'bt1358', 'st347', 'st274', 'st296', 'st349', 'st428'\n");
+    printf("  --frame-layout <value>  Override or set the video frame layout. The <value> is one of the following:\n");
+    printf("                              'fullframe', 'separatefield', 'singlefield', 'mixedfield', 'segmentedframe'\n");
+    printf("  --field-dom <value>     Override or set which field is first in temporal order. The <value> is 1 or 2\n");
+    printf("  --transfer-ch <value>   Override or set the transfer characteristic label\n");
+    printf("                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
+    printf("                              'bt470', 'bt709', 'st240', 'st274', 'bt1361', 'linear', 'dcdm',\n");
+    printf("                              'iec61966', 'bt2020', 'st2084', 'hlg'\n");
+    printf("  --coding-eq <value>     Override or set the coding equations label\n");
+    printf("                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
+    printf("                              'bt601', 'bt709', 'st240', 'ycgco', 'gbr', 'bt2020'\n");
+    printf("  --color-prim <value>    Override or set the color primaries label\n");
+    printf("                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
+    printf("                              'st170', 'bt470', 'bt709', 'bt2020', 'dcdm', 'p3'\n");
+    printf("  --color-siting <value>  Override or set the color siting. The <value> is one of the following:\n");
+    printf("                              'cositing', 'horizmp', '3tap', 'quincunx', 'bt601', 'linealt', 'vertmp', 'unknown'\n");
+    printf("                              (Note that 'bt601' is deprecated in SMPTE ST 377-1. Use 'cositing' instead)\n");
+    printf("  --black-level <value>   Override or set the black reference level\n");
+    printf("  --white-level <value>   Override or set the white reference level\n");
+    printf("  --color-range <value>   Override or set the color range\n");
+    printf("  --comp-max-ref <value>  Override or set the RGBA component maximum reference level\n");
+    printf("  --comp-min-ref <value>  Override or set the RGBA component minimum reference level\n");
+    printf("  --scan-dir <value>      Override or set the RGBA scanning direction\n");
+    printf("  --display-primaries <value>    Override or set the mastering display primaries.\n");
+    printf("                                 The <value> is an array of 6 unsigned integers separated by a ','.\n");
+    printf("  --display-white-point <value>  Override or set the mastering display white point chromaticity.\n");
+    printf("                                 The <value> is an array of 2 unsigned integers separated by a ','.\n");
+    printf("  --display-max-luma <value>     Override or set the mastering display maximum luminance.\n");
+    printf("  --display-min-luma <value>     Override or set the mastering display minimum luminance.\n");
+    printf("  --rdd36-opaque              Override and treat RDD-36 4444 or 4444 XQ as opaque by omitting the Alpha Sample Depth property\n");
+    printf("  --rdd36-comp-depth <value>  Override of set component depth for RDD-36. Defaults to 10 if not present in input file\n");
+    printf("  --active-width          Override or set the Active Width of the active area rectangle\n");
+    printf("  --active-height         Override or set the Active Height of the active area rectangle\n");
+    printf("  --active-x-offset       Override or set the Active X Offset of the active area rectangle\n");
+    printf("  --active-y-offset       Override or set the Active Y Offset of the active area rectangle\n");
+    printf("  --display-f2-offset     Override or set the default Display F2 Offset if it is not extracted from the essence\n");
+    printf("  --center-cut-4-3        Override or add the Alternative Center Cut 4:3\n");
+    printf("  --center-cut-14-9       Override or add the Alternative Center Cut 14:9\n");
+    printf("  --ignore-input-desc     Don't use input MXF file descriptor properties to fill in missing information\n");
+    printf("  --track-map <expr>      Map input audio channels to output tracks\n");
+    printf("                          The default is 'mono', except if --clip-wrap option is set for op1a it is 'singlemca'\n");
+    printf("                          See below for details of the <expr> format\n");
+    printf("  --dump-track-map        Dump the output audio track map to stderr.\n");
+    printf("                          The dumps consists of a list output tracks, where each output track channel\n");
+    printf("                          is shown as '<output track channel> <- <input channel>\n");
+    printf("  --dump-track-map-exit   Same as --dump-track-map, but exit immediately afterwards\n");
+    printf("  --assume-d10-30         Assume a generic MPEG video elementary stream is actually D-10 30\n");
+    printf("  --assume-d10-40         Assume a generic MPEG video elementary stream is actually D-10 40\n");
+    printf("  --assume-d10-50         Assume a generic MPEG video elementary stream is actually D-10 50\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/as11rdd9/op1a/rdd9/d10:\n");
+    printf("    --head-fill <bytes>     Reserve minimum <bytes> at the end of the header metadata using a KLV Fill\n");
+    printf("                            Add a 'K' suffix for kibibytes and 'M' for mibibytes\n");
+    printf("\n");
+    printf("  as02:\n");
+    printf("    --mic-type <type>       Media integrity check type: 'md5' or 'none'. Default 'md5'\n");
+    printf("    --mic-file              Calculate checksum for entire essence component file. Default is essence only\n");
+    printf("    --shim-name <name>      Set ShimName element value in shim.xml file to <name>. Default is '%s'\n", DEFAULT_SHIM_NAME);
+    printf("    --shim-id <id>          Set ShimID element value in shim.xml file to <id>. Default is '%s'\n", DEFAULT_SHIM_ID);
+    printf("    --shim-annot <str>      Set AnnotationText element value in shim.xml file to <str>. Default is '%s'\n", DEFAULT_SHIM_ANNOTATION);
+    printf("\n");
+    printf("  as02/as11op1a/op1a/rdd9/as10:\n");
+    printf("    --part <interval>       Video essence partition interval in frames in input edit rate units, or (floating point) seconds with 's' suffix. Default single partition\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/as11rdd9:\n");
+    printf("    --dm <fwork> <name> <value>    Set descriptive framework property. <fwork> is 'as11' or 'dpp'\n");
+    printf("    --dm-file <fwork> <name>       Parse and set descriptive framework properties from text file <name>. <fwork> is 'as11' or 'dpp'\n");
+    printf("    --seg <name>                   Parse and set segmentation data from text file <name>\n");
+    printf("    --pass-dm                      Copy descriptive metadata from the input file. The metadata can be overidden by other options\n");
+    printf("    --norm-pass-dm                 Same as --pass-dm, but also normalise strings to always have a null terminator. This is a workaround for products that fail to handle zero size string properties.\n");
+    printf("    --spec-id <id>                 Set the AS-11 specification identifier labels associated with <id>\n");
+    printf("                                   The <id> is one of the following:\n");
+    printf("                                       as11-x1 : AMWA AS-11 X1, delivery of finished UHD programs to Digital Production Partnership (DPP) broadcasters\n");
+    printf("                                       as11-x2 : AMWA AS-11 X2, delivery of finished HD AVC Intra programs to a broadcaster or publisher\n");
+    printf("                                       as11-x3 : AMWA AS-11 X3, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
+    printf("                                       as11-x4 : AMWA AS-11 X4, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
+    printf("                                       as11-x5 : AMWA AS-11 X5, delivery of finished UHD TV Commericals and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
+    printf("                                       as11-x6 : AMWA AS-11 X6, delivery of finished HD TV Commercials and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
+    printf("                                       as11-x7 : AMWA AS-11 X7, delivery of finished SD D10 programs to a broadcaster or publisher\n");
+    printf("                                       as11-x8 : AMWA AS-11 X8, delivery of finished HD (MPEG-2) programs to North American Broadcasters Association (NABA) broadcasters\n");
+    printf("                                       as11-x9 : AMWA AS-11 X9, delivery of finished HD TV Programmes (AVC) to North American Broadcasters Association (NABA) broadcasters\n");
+    printf("\n");
+    printf("  as02/as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
+    printf("    --afd <value>           Active Format Descriptor 4-bit code from table 1 in SMPTE ST 2016-1. Default is input file's value or not set\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
+    printf("    --single-pass           Write file in a single pass\n");
+    printf("                            Header and body partitions will be incomplete for as11op1a/op1a if the number if essence container bytes per edit unit is variable\n");
+    printf("    --file-md5              Calculate an MD5 checksum of the output file. This requires writing in a single pass (--single-pass is assumed)\n");
+    printf("\n");
+    printf("  as11op1a/op1a:\n");
+    printf("    --pass-anc <filter>     Pass through ST 436 ANC data tracks\n");
+    printf("                            <filter> is a comma separated list of ANC data types to pass through\n");
+    printf("                            The following ANC data types are supported in <filter>:\n");
+    printf("                                all      : pass through all ANC data\n");
+    printf("                                st2020   : SMPTE ST 2020 / RDD 6 audio metadata\n");
+    printf("                                st2016   : SMPTE ST 2016-3/ AFD, bar and pan-scan data\n");
+    printf("                                sdp      : SMPTE RDD 8 / OP-47 Subtitling Distribution Packet data\n");
+    printf("                                st12     : SMPTE ST 12 Ancillary timecode\n");
+    printf("                                st334    : SMPTE ST 334-1 EIA 708B, EIA 608 and data broadcast (DTV)\n");
+    printf("    --pass-vbi              Pass through ST 436 VBI data tracks\n");
+    printf("    --st436-mf <count>      Set the <count> of frames to examine for ST 436 ANC/VBI manifest info. Default is %u\n", DEFAULT_ST436_MANIFEST_COUNT);
+    printf("                            The manifest is used at the start to determine whether an output ANC data track is created\n");
+    printf("                            Set <count> to 0 to always create an ANC data track if the input has one\n");
+    printf("    --anc-const <size>      Use to indicate that the ST 436 ANC frame element data, excl. key and length, has a constant <size>. A variable size is assumed by default\n");
+    printf("    --anc-max <size>        Use to indicate that the ST 436 ANC frame element data, excl. key and length, has a maximum <size>. A variable size is assumed by default\n");
+    printf("    --st2020-max            The ST 436 ANC maximum frame element data size for ST 2020 only is calculated from the extracted manifest. Option '--pass-anc st2020' is required.\n");
+    printf("    --vbi-const <size>      Use to indicate that the ST 436 VBI frame element data, excl. key and length, has a constant <size>. A variable size is assumed by default\n");
+    printf("    --vbi-max <size>        Use to indicate that the ST 436 VBI frame element data, excl. key and length, has a maximum <size>. A variable size is assumed by default\n");
+    printf("    --rdd6 <file>           Add ST 436 ANC data track containing 'static' RDD-6 audio metadata from XML <file>\n");
+    printf("                            The timecode fields are ignored, i.e. they are set to 'undefined' values in the RDD-6 metadata stream\n");
+    printf("    --rdd6-lines <lines>    A single or pair of line numbers, using ',' as the separator, for carriage of the RDD-6 ANC data. The default is a pair of numbers, '%u,%u'\n", DEFAULT_RDD6_LINES[0], DEFAULT_RDD6_LINES[1]);
+    printf("    --rdd6-sdid <sdid>      The SDID value indicating the first audio channel pair associated with the RDD-6 data. Default is %u\n", DEFAULT_RDD6_SDID);
+    printf("\n");
+    printf("  op1a/rdd9/d10:\n");
+    printf("    --xml-scheme-id <id>    Set the XML payload scheme identifier associated with the following --embed-xml option.\n");
+    printf("                            The <id> is one of the following:\n");
+    printf("                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
+    printf("                                * a UUID, formatted as a 'urn:uuid:...'or as 32 hexadecimal characters using a '.' or '-' seperator,\n");
+    printf("                                * 'as11', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.04010000\n");
+    printf("                            A default BMX scheme identifier is used if this option is not provided\n");
+    printf("    --xml-lang <tag>        Set the RFC 5646 language tag associated with the the following --embed-xml option.\n");
+    printf("                            Defaults to the xml:lang attribute in the root element or empty string if not present\n");
+    printf("    --embed-xml <filename>  Embed the XML from <filename> using the approach specified in SMPTE RP 2057\n");
+    printf("                            If the XML size is less than 64KB and uses UTF-8 or UTF-16 encoding (declared in\n");
+    printf("                            the XML prolog) then the XML data is included in the header metadata. Otherwise\n");
+    printf("                            a Generic Stream partition is used to hold the XML data.\n");
+    printf("\n");
+    printf("  op1a:\n");
+    printf("    --no-tc-track           Don't create a timecode track in either the material or file source package\n");
+    printf("    --min-part              Only use a header and footer MXF file partition. Use this for applications that don't support\n");
+    printf("                            separate partitions for header metadata, index tables, essence container data and footer\n");
+    printf("    --body-part             Create separate body partitions for essence data\n");
+    printf("                            and don't create separate body partitions for index table segments\n");
+    printf("    --repeat-index          Repeat the index table segments in the footer partition\n");
+    printf("    --clip-wrap             Use clip wrapping for a single sound track\n");
+    printf("    --mp-track-num          Use the material package track number property to define a track order. By default the track number is set to 0\n");
+    printf("    --aes-3                 Use AES-3 audio mapping\n");
+    printf("    --kag-size-512          Set KAG size to 512, instead of 1\n");
+    printf("    --system-item           Add system item\n");
+    printf("    --primary-package       Set the header metadata set primary package property to the top-level file source package\n");
+    printf("    --index-follows         The index partition follows the essence partition, even when it is CBE essence\n");
+    printf("\n");
+    printf("  op1a/rdd9:\n");
+    printf("    --ard-zdf-hdf           Use the ARD ZDF HDF profile\n");
+    printf("\n");
+    printf("  op1a/d10:\n");
+    printf("    --cbe-index-duration-0  Use duration=0 if index table is CBE\n");
+    printf("\n");
+    printf("  as10:\n");
+    printf("    --shim-name <name>      Shim name for AS10 (used for setting 'ShimName' metadata and setting video/sound parameters' checks)\n");
+    printf("                            list of known shims: %s\n", get_as10_shim_names().c_str());
+    printf("    --dm-file as10 <name>   Parse and set descriptive framework properties from text file <name>\n");
+    printf("                            N.B. 'ShimName' is the only mandatary property of AS10 metadata set\n");
+    printf("    --dm as10 <name> <value>    Set descriptive framework property\n");
+    printf("    --pass-dm               Copy descriptive metadata from the input file. The metadata can be overidden by other options\n");
+    printf("    --mpeg-checks [<name>]  Enable AS-10 compliancy checks. The file <name> is optional and contains expected descriptor values\n");
+    printf("    --loose-checks          Don't stop processing on detected compliancy violations\n");
+    printf("    --print-checks          Print default values of mpeg descriptors and report on descriptors either found in mpeg headers or copied from mxf headers\n");
+    printf("    --max-same-warnings <value>  Max same violations warnings logged, default 3\n");
+    printf("\n");
+    printf("  as11d10/d10:\n");
+    printf("    --d10-mute <flags>      Indicate using a string of 8 '0' or '1' which sound channels should be muted. The lsb is the rightmost digit\n");
+    printf("    --d10-invalid <flags>   Indicate using a string of 8 '0' or '1' which sound channels should be flagged invalid. The lsb is the rightmost digit\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
+    printf("    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
+    printf("    --fp-uid <umid>         Set the File Package UID. Autogenerated by default\n");
+    printf("\n");
+    printf("  avid:\n");
+    printf("    --project <name>        Set the Avid project name\n");
+    printf("    --tape <name>           Source tape name\n");
+    printf("    --import <name>         Source import name. <name> is one of the following:\n");
+    printf("                              - a file URL starting with 'file://'\n");
+    printf("                              - an absolute Windows (starts with '[A-Z]:') or *nix (starts with '/') filename\n");
+    printf("                              - a relative filename, which will be converted to an absolute filename\n");
+    printf("    --comment <string>      Add 'Comments' user comment to the MaterialPackage\n");
+    printf("    --desc <string>         Add 'Descript' user comment to the MaterialPackage\n");
+    printf("    --tag <name> <value>    Add <name> user comment to the MaterialPackage. Option can be used multiple times\n");
+    printf("    --locator <position> <comment> <color>\n");
+    printf("                            Add locator at <position> with <comment> and <color>\n");
+    printf("                            <position> format is o?hh:mm:sscff, where the optional 'o' indicates it is an offset\n");
+    printf("    --umid-type <type>      Set the UMID type that is generated for the Package UID properties.\n");
+    printf("                            The default <type> is 'aafsdk'.\n");
+    printf("                            The <type> is one of the following:\n");
+    printf("                              uuid       : UUID generation method\n");
+    printf("                              aafsdk     : same method as implemented in the AAF SDK\n");
+    printf("                                           This type is required to be compatible with some older Avid product versions\n");
+    printf("                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
+    printf("                              old-aafsdk : same method as implemented in revision 1.47 of AAF/ref-impl/src/impl/AAFUtils.c in the AAF SDK\n");
+    printf("                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
+    printf("    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
+    printf("    --mp-created <tstamp>   Set the Material Package creation date. Default is 'now'\n");
+    printf("    --psp-uid <umid>        Set the tape/import Source Package UID\n");
+    printf("                              tape: autogenerated by default\n");
+    printf("                              import: single input Material Package UID or autogenerated by default\n");
+    printf("    --psp-created <tstamp>  Set the tape/import Source Package creation date. Default is 'now'\n");
+    printf("    --ess-marks             Convert XDCAM Essence Marks to locators\n");
+    printf("    --allow-no-avci-head    Allow inputs with no AVCI header (512 bytes, sequence and picture parameter sets)\n");
+    printf("    --avid-gf               Use the Avid growing file flavour\n");
+    printf("    --avid-gf-dur <dur>     Set the duration which should be shown whilst the file is growing\n");
+    printf("                            The default value is the output duration\n");
+    printf("    --ignore-d10-aes3-flags   Ignore D10 AES3 audio validity flags and assume they are all valid\n");
+    printf("                              This workarounds an issue with Avid transfer manager which sets channel flags 4 to 8 to invalid\n");
+    printf("\n");
+    printf("  op1a/avid:\n");
+    printf("    --force-no-avci-head    Strip AVCI header (512 bytes, sequence and picture parameter sets) if present\n");
+    printf("\n");
+    printf("  wave:\n");
+    printf("    --orig <name>           Set originator in the Wave bext chunk. Default '%s'\n", DEFAULT_BEXT_ORIGINATOR);
+    printf("\n");
+    printf("  as02/op1a/as11op1a:\n");
+    printf("    --use-avc-subdesc       Use the AVC sub-descriptor rather than the MPEG video descriptor for AVC-Intra tracks\n");
+    printf("\n");
+    printf("  op1a/as11op1a/rdd9:\n");
+    printf("    --audio-layout <label>  Set the Wave essence descriptor channel assignment label which identifies the audio layout mode in operation\n");
+    printf("                            The <label> is one of the following:\n");
+    printf("                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
+    printf("                                * 'as11-mode-0', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02010000,\n");
+    printf("                                * 'as11-mode-1', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02020000,\n");
+    printf("                                * 'as11-mode-2', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02030000\n");
+    printf("                                * 'imf', which corresponds to urn:smpte:ul:060e2b34.0401010d.04020210.04010000\n");
+    printf("    --track-mca-labels <scheme> <file>  Insert audio labels defined in <file>. The 'as11' <scheme> will add an override and otherwise <scheme> is ignored\n");
+    printf("                                        The format of <file> is described in bmx/docs/mca_labels_format.md\n");
+    printf("                                        All tag symbols registered in the bmx code are available for use\n");
+    printf("                                        The 'as11' <scheme> will change the label associated with the 'chVIN' tag symbol to use the 'Visually Impaired Narrative' tag name, i.e. without a '-'\n");
+    printf("\n");
+    printf("Input options:\n");
+    printf("  --disable-tracks <tracks> A comma separated list of track indexes and/or ranges to disable.\n");
+    printf("                            A track is identified by the index reported by mxf2raw\n");
+    printf("                            A range of track indexes is specified as '<first>-<last>', e.g. 0-3\n");
+    printf("  --disable-audio           Disable audio tracks\n");
+    printf("  --disable-video           Disable video tracks\n");
+    printf("  --disable-data            Disable data tracks\n");
+    printf("\n\n");
+    printf("Notes:\n");
+    printf(" - filename pattern: Clip types producing a single output file may use a filename pattern with variables that get substituted\n");
+    printf("                     Pattern variables start with a '{' and end with a '}'. E.g. 'output_{type}_{fp_uuid}.mxf'\n");
+    printf("                     The following variables are available:\n");
+    printf("                       - {type}: Is replaced with the name for video, audio, data or mixed essence types\n");
+    printf("                                 See the --ess-type-names option for the default names and use the option to change them\n");
+    printf("                       - {mp_uuid}: The UUID material number in a material package UMID\n");
+    printf("                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
+    printf("                       - {mp_umid}: The material package UMID\n");
+    printf("                       - {fp_uuid}: The UUID material number in a file source package UMID\n");
+    printf("                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
+    printf("                       - {fp_umid}: The file source package UMID\n");
+    printf(" - <umid> format is 64 hexadecimal characters and any '.' and '-' characters are ignored\n");
+    printf(" - <uuid> format is 32 hexadecimal characters and any '.' and '-' characters are ignored\n");
+    printf(" - <tstamp> format is YYYY-MM-DDThh:mm:ss:qm where qm is in units of 1/250th second\n");
+    printf("\n");
+    printf(" The track mapping <expr> format is one of the following:\n");
+    printf("     'mono'     : each input audio channel is mapped to a single-channel output track\n");
+    printf("     'stereo'   : input audio channels are paired to stereo-channel output tracks\n");
+    printf("                  A silence channel is added to the last output track if the channel count is odd\n");
+    printf("     'singlemca': all input audio channels are mapped to a single multi-channel output track\n");
+    printf("     <pattern>  : a pattern defining how input channels map to output track channels - see below\n");
+    printf("\n");
+    printf(" The track mapping <pattern> specifies how input audio channels are mapped to output track channels\n");
+    printf(" A <pattern> consists of a list of <group>s separated by a ';'.\n");
+    printf(" A <group> starts with an optional 'm', followed by a list of <element> separated by a ','.\n");
+    printf("   An 'm' indicates that each channel in the <group> is mapped to separate single-channel output track.\n");
+    printf("   If an 'm' is not present then the channels are mapped to a single output track.\n");
+    printf(" A <element> is either a <channel>, <range>, <silence> or <remainder>.\n");
+    printf(" A <channel> is an input channel number starting from 0.\n");
+    printf("   The input channel number is the number derived from the input track order reported by mxf2raw for the\n");
+    printf("   input files in the same order and including any --disable input options. Each channel in a track\n");
+    printf("   contributes 1 to the overall channel number.\n");
+    printf(" A <range> is 2 <channel>s separated by a '-' and includes all channels starting with the first number\n");
+    printf("   and ending with the last number.\n");
+    printf(" A <silence> is 's' followed by a <count> and results in <count> silence channels added to the output track.\n");
+    printf(" A <remainder> is 'x', and results in all remaining channels being added to the output track.\n");
+    printf("\n");
+    printf("Here are some <pattern> examples:\n");
+    printf("    'mx'     : equivalent to 'mono'\n");
+    printf("    '0,1;x'  : the first 2 channels mapped to a stereo output track and all remaining channels mapped\n");
+    printf("               to a single multi-channel track\n");
+    printf("    '2-7;0,1': 6 channel output track followed by a 2 channel output track\n");
+    printf("    '0,1,s2' : 2 input channels plus 2 silence channels mapped to a single output track\n");
 }
 
 int main(int argc, const char** argv)
@@ -973,7 +980,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -984,13 +991,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_log_level(argv[cmdln_index + 1], &log_level))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1000,13 +1007,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_clip_type(argv[cmdln_index + 1], &clip_type, &clip_sub_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1016,7 +1023,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1027,13 +1034,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_essence_type_names(argv[cmdln_index + 1], &filename_essence_type_names))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1043,14 +1050,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 5 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing arguments for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_product_info(&argv[cmdln_index + 1], 5, &company_name, &product_name, &product_version,
                                     &version_string, &product_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid values '%s' etc. for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1061,13 +1068,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_timestamp(argv[cmdln_index + 1], &creation_date))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1082,7 +1089,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1105,13 +1112,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_rate(argv[cmdln_index + 1], &timecode_rate))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1122,7 +1129,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1133,13 +1140,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &start) != 1 || start < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1150,13 +1157,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &duration) != 1 || duration < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1170,14 +1177,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value <= 0 )
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1200,13 +1207,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &rt_factor) != 1 || rt_factor <= 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1221,13 +1228,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &gf_retries) != 1 || gf_retries == 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1238,13 +1245,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &gf_retry_delay) != 1 || gf_retry_delay < 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1255,13 +1262,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &gf_rate_after_fail) != 1 || gf_rate_after_fail <= 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1276,13 +1283,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1309,14 +1316,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1 ||
                 (uvalue % system_page_size) != 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1339,14 +1346,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_avci_header(argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3],
                                    &avci_header_inputs))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid values '%s', '%s', '%s' for Option '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3], argv[cmdln_index]);
                 return 1;
@@ -1365,13 +1372,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d:%d", &num, &den) != 2 || num <= 0 || den <= 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1388,13 +1395,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_vc2_mode(argv[cmdln_index + 1], &vc2_mode_flags))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1404,13 +1411,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_bool(argv[cmdln_index + 1], &user_locked))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1421,14 +1428,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value < -128 || value > 127)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1439,14 +1446,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value < -128 || value > 127)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1457,13 +1464,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_rate(argv[cmdln_index + 1], &rate))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1474,12 +1481,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1490,12 +1497,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_signal_standard(argv[cmdln_index + 1], &user_signal_standard)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1506,12 +1513,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_layout(argv[cmdln_index + 1], &user_frame_layout)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1522,12 +1529,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_field_dominance(argv[cmdln_index + 1], &user_field_dominance)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1538,12 +1545,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_transfer_ch(argv[cmdln_index + 1], &user_transfer_ch)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1554,12 +1561,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_coding_equations(argv[cmdln_index + 1], &user_coding_equations)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1570,12 +1577,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_color_primaries(argv[cmdln_index + 1], &user_color_primaries)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1586,12 +1593,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_color_siting(argv[cmdln_index + 1], &user_color_siting)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1602,12 +1609,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1618,12 +1625,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1634,12 +1641,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1650,12 +1657,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1666,12 +1673,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1682,12 +1689,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1698,12 +1705,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_three_color_primaries(argv[cmdln_index + 1], &three_color_primaries)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1714,12 +1721,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_color_primary(argv[cmdln_index + 1], &color_primary)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1730,12 +1737,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1746,12 +1753,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1766,14 +1773,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &value) != 1 ||
                 (value != 8 && value != 10))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1784,12 +1791,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1800,12 +1807,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1816,12 +1823,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1832,12 +1839,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1848,12 +1855,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1876,13 +1883,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_mic_type(argv[cmdln_index + 1], &mic_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1916,14 +1923,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &max_mpeg_check_same_warn_messages) != 1 ||
                 max_mpeg_check_same_warn_messages < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1933,7 +1940,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1947,7 +1954,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1958,7 +1965,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1969,7 +1976,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1980,14 +1987,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (as10_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as10_helper.SetFrameworkProperty(argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to set '%s' framework property '%s' to '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]);
                 return 1;
@@ -1995,7 +2002,7 @@ int main(int argc, const char** argv)
             if (as11_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as11_helper.SetFrameworkProperty(argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to set '%s' framework property '%s' to '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]);
                 return 1;
@@ -2006,14 +2013,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 2 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (as10_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as10_helper.ParseFrameworkFile(argv[cmdln_index + 1], argv[cmdln_index + 2]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to parse '%s' framework file '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2]);
                 return 1;
@@ -2021,7 +2028,7 @@ int main(int argc, const char** argv)
             if (as11_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as11_helper.ParseFrameworkFile(argv[cmdln_index + 1], argv[cmdln_index + 2]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to parse '%s' framework file '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2]);
                 return 1;
@@ -2032,7 +2039,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2052,13 +2059,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!as11_helper.ParseSpecificationId(argv[cmdln_index + 1]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2068,14 +2075,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value <= 0 || value > 255)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2094,13 +2101,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_anc_data_types(argv[cmdln_index + 1], &pass_anc))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2114,13 +2121,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2131,13 +2138,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2148,13 +2155,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2169,13 +2176,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2186,13 +2193,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2203,7 +2210,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2214,13 +2221,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_rdd6_lines(argv[cmdln_index + 1], rdd6_lines))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2230,14 +2237,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1 ||
                 uvalue < 1 || uvalue > 9)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2248,14 +2255,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!AS11Helper::ParseXMLSchemeId(argv[cmdln_index + 1], &next_embed_xml.scheme_id) &&
                 !parse_mxf_auid(argv[cmdln_index + 1], &next_embed_xml.scheme_id))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2265,7 +2272,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2276,7 +2283,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2352,13 +2359,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_d10_sound_flags(argv[cmdln_index + 1], &d10_mute_sound_flags))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2368,13 +2375,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_d10_sound_flags(argv[cmdln_index + 1], &d10_invalid_sound_flags))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2384,7 +2391,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2395,7 +2402,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2406,7 +2413,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2417,7 +2424,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2428,7 +2435,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for %s\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2439,7 +2446,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 2 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for %s\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2450,7 +2457,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for %s\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2459,7 +2466,7 @@ int main(int argc, const char** argv)
             locator.locator.comment = argv[cmdln_index + 2];
             if (!parse_color(argv[cmdln_index + 3], &locator.locator.color))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to read --locator <color> value '%s'\n", argv[cmdln_index + 3]);
                 return 1;
             }
@@ -2470,13 +2477,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_avid_umid_type(argv[cmdln_index + 1], &avid_umid_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2486,13 +2493,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_umid(argv[cmdln_index + 1], &mp_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2503,13 +2510,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_timestamp(argv[cmdln_index + 1], &mp_created))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2520,13 +2527,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_umid(argv[cmdln_index + 1], &fp_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2537,13 +2544,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_umid(argv[cmdln_index + 1], &psp_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2554,13 +2561,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_timestamp(argv[cmdln_index + 1], &psp_created))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2583,13 +2590,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &avid_gf_duration) != 1 || avid_gf_duration < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2608,7 +2615,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2619,13 +2626,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!track_mapper.ParseMapDef(argv[cmdln_index + 1]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2657,13 +2664,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_bytes_size(argv[cmdln_index + 1], &i64value) || i64value > UINT32_MAX)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2678,14 +2685,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!AppMCALabelHelper::ParseAudioLayoutMode(argv[cmdln_index + 1], &audio_layout_mode_label) &&
                 !parse_mxf_auid(argv[cmdln_index + 1], &audio_layout_mode_label))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2695,7 +2702,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2713,7 +2720,7 @@ int main(int argc, const char** argv)
     }
 
     if (st2020_max_size && (pass_anc.size() != 1 || *pass_anc.begin() != ST2020_ANC_DATA)) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "Option '--st2020-max' requires '--pass st2020'\n");
         return 1;
     }
@@ -2736,13 +2743,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Input Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_track_indexes(argv[cmdln_index + 1], &disable_track_indexes[input_filenames.size()]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Input Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2773,7 +2780,7 @@ int main(int argc, const char** argv)
                     }
                 } else if (!check_file_exists(argv[cmdln_index])) {
                     if (argv[cmdln_index][0] == '-') {
-                        usage(argv[0]);
+                        usage_ref(argv[0]);
                         fprintf(stderr, "Unknown Input Option '%s'\n", argv[cmdln_index]);
                     } else {
                         fprintf(stderr, "Failed to open input filename '%s'\n", argv[cmdln_index]);
@@ -2786,14 +2793,14 @@ int main(int argc, const char** argv)
     }
 
     if (input_filenames.empty()) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "No input filenames\n");
         return 1;
     }
 
     if (clip_type == CW_AS02_CLIP_TYPE || clip_type == CW_AVID_CLIP_TYPE) {
         if (uses_filename_pattern_variables(output_name)) {
-            usage(argv[0]);
+            usage_ref(argv[0]);
             fprintf(stderr, "Clip type '%s' does not support output filename pattern variables\n",
                     clip_type_to_string(clip_type, clip_sub_type));
             return 1;
@@ -2803,7 +2810,7 @@ int main(int argc, const char** argv)
     if (clip_sub_type == AS10_CLIP_SUB_TYPE) {
         const char *as10_shim_name = as10_helper.GetShimName();
         if (!as10_shim_name) {
-            usage(argv[0]);
+            usage_ref(argv[0]);
             fprintf(stderr, "Set required 'ShimName' property for as10 output\n");
             return 1;
         }
@@ -3267,7 +3274,7 @@ int main(int argc, const char** argv)
         if (!timecode_rate_set && !input_edit_rate_is_sampling_rate)
             timecode_rate = frame_rate;
         if (start_timecode_str && !parse_timecode(start_timecode_str, timecode_rate, &start_timecode)) {
-            usage(argv[0]);
+            usage_ref(argv[0]);
             log_error("Invalid value '%s' for Option '-t'\n", start_timecode_str);
             throw false;
         }
@@ -3275,7 +3282,7 @@ int main(int argc, const char** argv)
         if (partition_interval_str) {
             if (!parse_partition_interval(partition_interval_str, frame_rate, &partition_interval))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 log_error("Invalid value '%s' for Option '--part'\n", partition_interval_str);
                 throw false;
             }
@@ -3297,7 +3304,7 @@ int main(int argc, const char** argv)
             if (!parse_position(locators[i].position_str, position_start_timecode, timecode_rate,
                                 &locators[i].locator.position))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 log_error("Invalid value '%s' for Option '--locator'\n", locators[i].position_str);
                 throw false;
             }

--- a/apps/mxf2raw/mxf2raw.cpp
+++ b/apps/mxf2raw/mxf2raw.cpp
@@ -1600,112 +1600,119 @@ static bool parse_info_format(const char *format_str, InfoFormat *format)
     return true;
 }
 
-static void usage(const char *cmd)
+static void usage_ref(const char *cmd)
 {
     fprintf(stderr, "%s\n", get_app_version_info(APP_NAME).c_str());
-    fprintf(stderr, "Output MXF file metadata and raw essence\n");
+    fprintf(stderr, "Run '%s -h' to show detailed commandline usage.\n", strip_path(cmd).c_str());
     fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s <<Options>> [<<Input Options>> <filename>]+\n", cmd);
-    fprintf(stderr, "   Use <filename> '-' for standard input\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, " -h | --help           Show usage and exit\n");
-    fprintf(stderr, " -v | --version        Print version info to stderr\n");
-    fprintf(stderr, " -l <file>             Log filename. Default log to stderr\n");
-    fprintf(stderr, " --log-level <level>   Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " --file-chksum-only <type>\n");
-    fprintf(stderr, "                       Calculate checksum of the file(s) and exit\n");
-    fprintf(stderr, "                       <type> is one of the following: 'crc32', 'md5', 'sha1'\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " --group               Use the group reader instead of the sequence reader\n");
-    fprintf(stderr, "                       Use this option if the files have different material packages\n");
-    fprintf(stderr, "                       but actually belong to the same virtual package / group\n");
-    fprintf(stderr, " --no-reorder          Don't attempt to re-order the inputs, based on timecode, when constructing a sequence\n");
-    fprintf(stderr, "                       Use this option for files with broken timecode\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " --check-end           Check that the last edit unit (start + duration - 1) can be read when opening the files\n");
-    fprintf(stderr, " --check-complete      Check that the input file structure info can be read and is complete\n");
-    fprintf(stderr, " --check-app-issues    Check that there are no known issues with the APP (Archive Preservation Project) file\n");
-    fprintf(stderr, " --check-app-crc32     Check APP essence CRC-32 data\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " -i | --info           Extract input information. Default output is to stdout\n");
-    fprintf(stderr, " --info-format <fmt>   Input info format. 'text' or 'xml'. Default 'text'\n");
-    fprintf(stderr, " --info-file <name>    Input info output file <name>\n");
-    fprintf(stderr, " --track-chksum <type> Calculate checksum of the track essence data\n");
-    fprintf(stderr, "                       <type> is one of the following: 'crc32', 'md5', 'sha1'\n");
-    fprintf(stderr, " --file-chksum <type>  Calculate checksum of the input file(s)\n");
-    fprintf(stderr, "                       <type> is one of the following: 'crc32', 'md5', 'sha1'\n");
-    fprintf(stderr, " --as11                Extract AS-11 and UK DPP metadata\n");
-    fprintf(stderr, " --as10                Extract AS-10 metadata\n");
-    fprintf(stderr, " --app                 Extract APP metadata\n");
-    fprintf(stderr, " --app-events <mask>   Extract APP events metadata\n");
-    fprintf(stderr, "                       <mask> is a sequence of event types (e.g. dtv) identified using the following characters:\n");
-    fprintf(stderr, "                           d=digibeta dropout, p=PSE failure, t=timecode break, v=VTR error\n");
-    fprintf(stderr, " --no-app-events-tc    Don't extract timecodes from the essence container to associate with the APP events metadata\n");
-    fprintf(stderr, " --app-crc32 <fname>   Extract APP CRC-32 frame data to <fname>\n");
-    fprintf(stderr, " --app-tc <fname>      Extract APP timecodes to <fname>\n");
-    fprintf(stderr, " --all-tc <fname>      Extract header and content package metadata timecodes to <fname>\n");
-    fprintf(stderr, "                       The list of timecodes extracted for each frame is as follows:\n");
-    fprintf(stderr, "                         frame position, material package, file source package, physical source package,\n");
-    fprintf(stderr, "                         5 x Avid auxiliary, system item user, system item creation,\n");
-    fprintf(stderr, "                         4 x system scheme 1 timecode array\n");
-    fprintf(stderr, "                       The header metadata timecodes are limited to the set extracted by bmx and what bmx accepts\n");
-    fprintf(stderr, "                       If the timecode property is not present then __:__:__:__ is printed\n");
-    fprintf(stderr, " --index               Extract index tables\n");
-    fprintf(stderr, " --avid                Extract Avid metadata\n");
-    fprintf(stderr, " --st436-mf <count>    Set the <count> of frames to examine for ST 436 ANC/VBI manifest info. Default is %u\n", DEFAULT_ST436_MANIFEST_COUNT);
-    fprintf(stderr, " --rdd6 <frames> <filename>\n");
-    fprintf(stderr, "                       Extract RDD-6 audio metadata from <frames> to XML <filename>.\n");
-    fprintf(stderr, "                       <frames> can either be a single frame or a range using '-' as a separator\n");
-    fprintf(stderr, "                       RDD-6 metadata is extracted from the first frame and program description text is accumulated using the other frames\n");
-    fprintf(stderr, "                       Not all frames will be required if a complete program text has been extracted\n");
-    fprintf(stderr, " --mca-detail          Show detailed MCA channel label information\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " -p | --ess-out <prefix>\n");
-    fprintf(stderr, "                       Extract essence to files starting with <prefix> and suffix '.raw'\n");
-    fprintf(stderr, " --wrap-klv <mask>     Wrap essence frames in KLV using the input Key and an 8-byte Length\n");
-    fprintf(stderr, "                       The filename suffix is '.klv' rather than '.raw'\n");
-    fprintf(stderr, "                       <mask> is a sequence of characters which identify which data types to wrap\n");
-    fprintf(stderr, "                           v=video, a=audio, d=data\n");
-    fprintf(stderr, " --read-ess            Read the essence data, even when no other option requires it\n");
-    fprintf(stderr, " --deint               De-interleave multi-channel / AES-3 sound\n");
-    fprintf(stderr, " --start <count>       Set the start edit unit to read from. Default is 0\n");
-    fprintf(stderr, " --dur <count>         Set the duration in edit units. Default is minimum available duration\n");
-    fprintf(stderr, " --nopc                Don't include pre-charge frames\n");
-    fprintf(stderr, " --noro                Don't include roll-out frames\n");
-    fprintf(stderr, " --rt <factor>         Read at realtime rate x <factor>, where <factor> is a floating point value\n");
-    fprintf(stderr, "                       <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
+}
+
+static void usage(const char *cmd)
+{
+    printf("%s\n", get_app_version_info(APP_NAME).c_str());
+    printf("Output MXF file metadata and raw essence\n");
+    printf("\n");
+    printf("Usage: %s <<Options>> [<<Input Options>> <filename>]+\n", strip_path(cmd).c_str());
+    printf("   Use <filename> '-' for standard input\n");
+    printf("Options:\n");
+    printf(" -h | --help           Show usage and exit\n");
+    printf(" -v | --version        Print version info to stderr\n");
+    printf(" -l <file>             Log filename. Default log to stderr\n");
+    printf(" --log-level <level>   Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
+    printf("\n");
+    printf(" --file-chksum-only <type>\n");
+    printf("                       Calculate checksum of the file(s) and exit\n");
+    printf("                       <type> is one of the following: 'crc32', 'md5', 'sha1'\n");
+    printf("\n");
+    printf(" --group               Use the group reader instead of the sequence reader\n");
+    printf("                       Use this option if the files have different material packages\n");
+    printf("                       but actually belong to the same virtual package / group\n");
+    printf(" --no-reorder          Don't attempt to re-order the inputs, based on timecode, when constructing a sequence\n");
+    printf("                       Use this option for files with broken timecode\n");
+    printf("\n");
+    printf(" --check-end           Check that the last edit unit (start + duration - 1) can be read when opening the files\n");
+    printf(" --check-complete      Check that the input file structure info can be read and is complete\n");
+    printf(" --check-app-issues    Check that there are no known issues with the APP (Archive Preservation Project) file\n");
+    printf(" --check-app-crc32     Check APP essence CRC-32 data\n");
+    printf("\n");
+    printf(" -i | --info           Extract input information. Default output is to stdout\n");
+    printf(" --info-format <fmt>   Input info format. 'text' or 'xml'. Default 'text'\n");
+    printf(" --info-file <name>    Input info output file <name>\n");
+    printf(" --track-chksum <type> Calculate checksum of the track essence data\n");
+    printf("                       <type> is one of the following: 'crc32', 'md5', 'sha1'\n");
+    printf(" --file-chksum <type>  Calculate checksum of the input file(s)\n");
+    printf("                       <type> is one of the following: 'crc32', 'md5', 'sha1'\n");
+    printf(" --as11                Extract AS-11 and UK DPP metadata\n");
+    printf(" --as10                Extract AS-10 metadata\n");
+    printf(" --app                 Extract APP metadata\n");
+    printf(" --app-events <mask>   Extract APP events metadata\n");
+    printf("                       <mask> is a sequence of event types (e.g. dtv) identified using the following characters:\n");
+    printf("                           d=digibeta dropout, p=PSE failure, t=timecode break, v=VTR error\n");
+    printf(" --no-app-events-tc    Don't extract timecodes from the essence container to associate with the APP events metadata\n");
+    printf(" --app-crc32 <fname>   Extract APP CRC-32 frame data to <fname>\n");
+    printf(" --app-tc <fname>      Extract APP timecodes to <fname>\n");
+    printf(" --all-tc <fname>      Extract header and content package metadata timecodes to <fname>\n");
+    printf("                       The list of timecodes extracted for each frame is as follows:\n");
+    printf("                         frame position, material package, file source package, physical source package,\n");
+    printf("                         5 x Avid auxiliary, system item user, system item creation,\n");
+    printf("                         4 x system scheme 1 timecode array\n");
+    printf("                       The header metadata timecodes are limited to the set extracted by bmx and what bmx accepts\n");
+    printf("                       If the timecode property is not present then __:__:__:__ is printed\n");
+    printf(" --index               Extract index tables\n");
+    printf(" --avid                Extract Avid metadata\n");
+    printf(" --st436-mf <count>    Set the <count> of frames to examine for ST 436 ANC/VBI manifest info. Default is %u\n", DEFAULT_ST436_MANIFEST_COUNT);
+    printf(" --rdd6 <frames> <filename>\n");
+    printf("                       Extract RDD-6 audio metadata from <frames> to XML <filename>.\n");
+    printf("                       <frames> can either be a single frame or a range using '-' as a separator\n");
+    printf("                       RDD-6 metadata is extracted from the first frame and program description text is accumulated using the other frames\n");
+    printf("                       Not all frames will be required if a complete program text has been extracted\n");
+    printf(" --mca-detail          Show detailed MCA channel label information\n");
+    printf("\n");
+    printf(" -p | --ess-out <prefix>\n");
+    printf("                       Extract essence to files starting with <prefix> and suffix '.raw'\n");
+    printf(" --wrap-klv <mask>     Wrap essence frames in KLV using the input Key and an 8-byte Length\n");
+    printf("                       The filename suffix is '.klv' rather than '.raw'\n");
+    printf("                       <mask> is a sequence of characters which identify which data types to wrap\n");
+    printf("                           v=video, a=audio, d=data\n");
+    printf(" --read-ess            Read the essence data, even when no other option requires it\n");
+    printf(" --deint               De-interleave multi-channel / AES-3 sound\n");
+    printf(" --start <count>       Set the start edit unit to read from. Default is 0\n");
+    printf(" --dur <count>         Set the duration in edit units. Default is minimum available duration\n");
+    printf(" --nopc                Don't include pre-charge frames\n");
+    printf(" --noro                Don't include roll-out frames\n");
+    printf(" --rt <factor>         Read at realtime rate x <factor>, where <factor> is a floating point value\n");
+    printf("                       <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
 #if defined(_WIN32)
-    fprintf(stderr, " --no-seq-scan         Do not set the sequential scan hint for optimizing file caching\n");
+    printf(" --no-seq-scan         Do not set the sequential scan hint for optimizing file caching\n");
 #if !defined(__MINGW32__)
-    fprintf(stderr, " --mmap-file           Use memory-mapped file I/O for the MXF files\n");
-    fprintf(stderr, "                       Note: this may reduce file I/O performance and was found to be slower over network drives\n");
+    printf(" --mmap-file           Use memory-mapped file I/O for the MXF files\n");
+    printf("                       Note: this may reduce file I/O performance and was found to be slower over network drives\n");
 #endif
 #endif
-    fprintf(stderr, " --gf                  Support growing files. Retry reading a frame when it fails\n");
-    fprintf(stderr, " --gf-retries <max>    Set the maximum times to retry reading a frame. The default is %u.\n", DEFAULT_GF_RETRIES);
-    fprintf(stderr, " --gf-delay <sec>      Set the delay (in seconds) between a failure to read and a retry. The default is %f.\n", DEFAULT_GF_RETRY_DELAY);
-    fprintf(stderr, " --gf-rate <factor>    Limit the read rate to realtime rate x <factor> after a read failure. The default is %f\n", DEFAULT_GF_RATE_AFTER_FAIL);
-    fprintf(stderr, "                       <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
-    fprintf(stderr, " --disable-indexing-file   Use this option to stop the reader creating an index of the partitions and essence positions in the file up front\n");
-    fprintf(stderr, "                           This option can be used to avoid indexing files containing many partitions\n");
+    printf(" --gf                  Support growing files. Retry reading a frame when it fails\n");
+    printf(" --gf-retries <max>    Set the maximum times to retry reading a frame. The default is %u.\n", DEFAULT_GF_RETRIES);
+    printf(" --gf-delay <sec>      Set the delay (in seconds) between a failure to read and a retry. The default is %f.\n", DEFAULT_GF_RETRY_DELAY);
+    printf(" --gf-rate <factor>    Limit the read rate to realtime rate x <factor> after a read failure. The default is %f\n", DEFAULT_GF_RATE_AFTER_FAIL);
+    printf("                       <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
+    printf(" --disable-indexing-file   Use this option to stop the reader creating an index of the partitions and essence positions in the file up front\n");
+    printf("                           This option can be used to avoid indexing files containing many partitions\n");
     if (mxf_http_is_supported()) {
-        fprintf(stderr, " --http-min-read <bytes>\n");
-        fprintf(stderr, "                       Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
-        fprintf(stderr, " --http-disable-seek   Disable seeking when reading file over HTTP\n");
+        printf(" --http-min-read <bytes>\n");
+        printf("                       Set the minimum number of bytes to read when accessing a file over HTTP. The default is %u.\n", DEFAULT_HTTP_MIN_READ);
+        printf(" --http-disable-seek   Disable seeking when reading file over HTTP\n");
     }
-    fprintf(stderr, "\n");
-    fprintf(stderr, " --text-out <prefix>   Extract text based objects to files starting with <prefix>\n");
-    fprintf(stderr, "                       and suffix '.xml' if it is XML and otherwise '.txt'\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Input options:\n");
-    fprintf(stderr, " --disable-tracks <tracks> A comma separated list of track indexes and/or ranges to disable when reading essence data.\n");
-    fprintf(stderr, "                           A track is identified by the index reported by mxf2raw\n");
-    fprintf(stderr, "                           A range of track indexes is specified as '<first>-<last>', e.g. 0-3\n");
-    fprintf(stderr, " --disable-audio       Disable audio tracks when reading essence data\n");
-    fprintf(stderr, " --disable-video       Disable video tracks when reading essence data\n");
-    fprintf(stderr, " --disable-data        Disable data tracks when reading essence data\n");
-    fprintf(stderr, "\n");
+    printf("\n");
+    printf(" --text-out <prefix>   Extract text based objects to files starting with <prefix>\n");
+    printf("                       and suffix '.xml' if it is XML and otherwise '.txt'\n");
+    printf("\n");
+    printf("Input options:\n");
+    printf(" --disable-tracks <tracks> A comma separated list of track indexes and/or ranges to disable when reading essence data.\n");
+    printf("                           A track is identified by the index reported by mxf2raw\n");
+    printf("                           A range of track indexes is specified as '<first>-<last>', e.g. 0-3\n");
+    printf(" --disable-audio       Disable audio tracks when reading essence data\n");
+    printf(" --disable-video       Disable video tracks when reading essence data\n");
+    printf(" --disable-data        Disable data tracks when reading essence data\n");
+    printf("\n");
 }
 
 int main(int argc, const char** argv)
@@ -1805,7 +1812,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1816,13 +1823,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_log_level(argv[cmdln_index + 1], &log_level))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1832,13 +1839,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_checksum_type(argv[cmdln_index + 1], &checkum_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1886,13 +1893,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_info_format(argv[cmdln_index + 1], &info_format))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1903,7 +1910,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1915,13 +1922,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_checksum_type(argv[cmdln_index + 1], &checkum_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1935,13 +1942,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_checksum_type(argv[cmdln_index + 1], &checkum_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1972,13 +1979,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_app_events_mask(argv[cmdln_index + 1], &app_events_mask))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1995,7 +2002,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2008,7 +2015,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2021,7 +2028,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2047,13 +2054,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2066,13 +2073,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 2 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (parse_rdd6_frames(argv[cmdln_index + 1], &rdd6_frame_min, &rdd6_frame_max) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2091,7 +2098,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2104,13 +2111,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_wrap_klv_mask(argv[cmdln_index + 1], &wrap_klv_mask))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2129,13 +2136,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &start) != 1 || start < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2146,13 +2153,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &duration) != 1 || duration < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2170,13 +2177,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &rt_factor) != 1 || rt_factor <= 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2203,13 +2210,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &gf_retries) != 1 || gf_retries == 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2220,13 +2227,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &gf_retry_delay) != 1 || gf_retry_delay < 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2237,13 +2244,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &gf_rate_after_fail) != 1 || gf_rate_after_fail <= 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2258,7 +2265,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2270,13 +2277,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2298,11 +2305,11 @@ int main(int argc, const char** argv)
     }
 
     if (cmdln_index + 1 > argc) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "Missing parameters\n");
         return 1;
     } else if (cmdln_index >= argc) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "No <filename> given\n");
         return 1;
     }
@@ -2317,13 +2324,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_track_indexes(argv[cmdln_index + 1], &disable_track_indexes[input_filenames.size()]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2354,7 +2361,7 @@ int main(int argc, const char** argv)
                     }
                 } else if (!check_file_exists(argv[cmdln_index])) {
                     if (argv[cmdln_index][0] == '-') {
-                        usage(argv[0]);
+                        usage_ref(argv[0]);
                         fprintf(stderr, "Unknown argument '%s'\n", argv[cmdln_index]);
                     } else {
                         fprintf(stderr, "Failed to open input filename '%s'\n", argv[cmdln_index]);

--- a/apps/raw2bmx/raw2bmx.cpp
+++ b/apps/raw2bmx/raw2bmx.cpp
@@ -394,451 +394,458 @@ static bool parse_avci_guess(const char *str, bool *interlaced, bool *progressiv
     return false;
 }
 
-static void usage(const char *cmd)
+static void usage_ref(const char *cmd)
 {
     fprintf(stderr, "%s\n", get_app_version_info(APP_NAME).c_str());
-    fprintf(stderr, "Create MXF files from raw essence files\n");
+    fprintf(stderr, "Run '%s -h' to show detailed commandline usage.\n", strip_path(cmd).c_str());
     fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s <<Options>> [<<Input Options>> <Input>]+\n", cmd);
-    fprintf(stderr, "Options (* means option is required):\n");
-    fprintf(stderr, "  -h | --help             Show usage and exit\n");
-    fprintf(stderr, "  -v | --version          Print version info\n");
-    fprintf(stderr, "  -l <file>               Log filename. Default log to stderr/stdout\n");
-    fprintf(stderr, " --log-level <level>      Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
-    fprintf(stderr, "  -t <type>               Clip type: as02, as11op1a, as11d10, op1a, avid, d10, rdd9, as10, wave, imf. Default is op1a\n");
-    fprintf(stderr, "                          Note that an 'op1a' or 'as11op1a' output file type could be signalled as other operational patterns if there is a Timed Text track\n");
-    fprintf(stderr, "* -o <name>               as02: <name> is a bundle name\n");
-    fprintf(stderr, "                          as11op1a/as11d10/op1a/d10/rdd9/as10/wave: <name> is a filename or filename pattern (see Notes at the end)\n");
-    fprintf(stderr, "                          avid: <name> is a filename prefix\n");
-    fprintf(stderr, "  --ess-type-names <names>  A comma separated list of 4 names for video, audio, data or mixed essence types\n");
-    fprintf(stderr, "                            The names can be used to replace {type} in output filename patterns\n");
-    fprintf(stderr, "                            The default names are: video,audio,data,mixed\n");
-    fprintf(stderr, "  --prod-info <cname>\n");
-    fprintf(stderr, "              <pname>\n");
-    fprintf(stderr, "              <ver>\n");
-    fprintf(stderr, "              <verstr>\n");
-    fprintf(stderr, "              <uid>\n");
-    fprintf(stderr, "                          Set the product info in the MXF Identification set\n");
-    fprintf(stderr, "                          <cname> is a string and is the Company Name property\n");
-    fprintf(stderr, "                          <pname> is a string and is the Product Name property\n");
-    fprintf(stderr, "                          <ver> has format '<major>.<minor>.<patch>.<build>.<release>' and is the Product Version property. Set to '0.0.0.0.0' to omit it\n");
-    fprintf(stderr, "                          <verstr> is a string and is the Version String property\n");
-    fprintf(stderr, "                          <uid> is a UUID (see Notes at the end) and is the Product UID property\n");
-    fprintf(stderr, "  --create-date <tstamp>  Set the creation date in the MXF Identification set. Default is 'now'\n");
-    fprintf(stderr, "  -f <rate>               Set the frame rate, overriding any frame rate parsed from the essence data\n");
-    fprintf(stderr, "                          The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
-    fprintf(stderr, "  --dflt-rate <rate>      Set the default frame rate which is used when no rate is provided by the essence data. Without this option the default is 25\n");
-    fprintf(stderr, "                          The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
-    fprintf(stderr, "  -y <hh:mm:sscff>        Start timecode. Default 00:00:00:00\n");
-    fprintf(stderr, "                          The c character in the pattern should be ':' for non-drop frame; any other character indicates drop frame\n");
-    fprintf(stderr, "  --clip <name>           Set the clip name\n");
-    fprintf(stderr, "  --dur <frame>           Set the duration in frames in frame rate units. Default is minimum input duration\n");
-    fprintf(stderr, "  --rt <factor>           Wrap at realtime rate x <factor>, where <factor> is a floating point value\n");
-    fprintf(stderr, "                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
-    fprintf(stderr, "  --avcihead <format> <file> <offset>\n");
-    fprintf(stderr, "                          Default AVC-Intra sequence header data (512 bytes) to use when the input file does not have it\n");
-    fprintf(stderr, "                          <format> is a comma separated list of one or more of the following integer values:\n");
+}
+
+static void usage(const char *cmd)
+{
+    printf("%s\n", get_app_version_info(APP_NAME).c_str());
+    printf("Create MXF files from raw essence files\n");
+    printf("\n");
+    printf("Usage: %s <<Options>> [<<Input Options>> <Input>]+\n", strip_path(cmd).c_str());
+    printf("Options (* means option is required):\n");
+    printf("  -h | --help             Show usage and exit\n");
+    printf("  -v | --version          Print version info\n");
+    printf("  -l <file>               Log filename. Default log to stderr/stdout\n");
+    printf(" --log-level <level>      Set the log level. 0=debug, 1=info, 2=warning, 3=error. Default is 1\n");
+    printf("  -t <type>               Clip type: as02, as11op1a, as11d10, op1a, avid, d10, rdd9, as10, wave, imf. Default is op1a\n");
+    printf("                          Note that an 'op1a' or 'as11op1a' output file type could be signalled as other operational patterns if there is a Timed Text track\n");
+    printf("* -o <name>               as02: <name> is a bundle name\n");
+    printf("                          as11op1a/as11d10/op1a/d10/rdd9/as10/wave: <name> is a filename or filename pattern (see Notes at the end)\n");
+    printf("                          avid: <name> is a filename prefix\n");
+    printf("  --ess-type-names <names>  A comma separated list of 4 names for video, audio, data or mixed essence types\n");
+    printf("                            The names can be used to replace {type} in output filename patterns\n");
+    printf("                            The default names are: video,audio,data,mixed\n");
+    printf("  --prod-info <cname>\n");
+    printf("              <pname>\n");
+    printf("              <ver>\n");
+    printf("              <verstr>\n");
+    printf("              <uid>\n");
+    printf("                          Set the product info in the MXF Identification set\n");
+    printf("                          <cname> is a string and is the Company Name property\n");
+    printf("                          <pname> is a string and is the Product Name property\n");
+    printf("                          <ver> has format '<major>.<minor>.<patch>.<build>.<release>' and is the Product Version property. Set to '0.0.0.0.0' to omit it\n");
+    printf("                          <verstr> is a string and is the Version String property\n");
+    printf("                          <uid> is a UUID (see Notes at the end) and is the Product UID property\n");
+    printf("  --create-date <tstamp>  Set the creation date in the MXF Identification set. Default is 'now'\n");
+    printf("  -f <rate>               Set the frame rate, overriding any frame rate parsed from the essence data\n");
+    printf("                          The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
+    printf("  --dflt-rate <rate>      Set the default frame rate which is used when no rate is provided by the essence data. Without this option the default is 25\n");
+    printf("                          The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
+    printf("  -y <hh:mm:sscff>        Start timecode. Default 00:00:00:00\n");
+    printf("                          The c character in the pattern should be ':' for non-drop frame; any other character indicates drop frame\n");
+    printf("  --clip <name>           Set the clip name\n");
+    printf("  --dur <frame>           Set the duration in frames in frame rate units. Default is minimum input duration\n");
+    printf("  --rt <factor>           Wrap at realtime rate x <factor>, where <factor> is a floating point value\n");
+    printf("                          <factor> value 1.0 results in realtime rate, value < 1.0 slower and > 1.0 faster\n");
+    printf("  --avcihead <format> <file> <offset>\n");
+    printf("                          Default AVC-Intra sequence header data (512 bytes) to use when the input file does not have it\n");
+    printf("                          <format> is a comma separated list of one or more of the following integer values:\n");
     size_t i;
     for (i = 0; i < get_num_avci_header_formats(); i++)
-        fprintf(stderr, "                              %2" PRIszt ": %s\n", i, get_avci_header_format_string(i));
-    fprintf(stderr, "                          or set <format> to 'all' for all formats listed above\n");
-    fprintf(stderr, "                          The 512 bytes are extracted from <file> starting at <offset> bytes\n");
-    fprintf(stderr, "                          and incrementing 512 bytes for each format in the list\n");
-    fprintf(stderr, "  --ps-avcihead           Panasonic AVC-Intra sequence header data for Panasonic-compatible files that don't include the header data\n");
-    fprintf(stderr, "                          These formats are supported:\n");
+        printf("                              %2" PRIszt ": %s\n", i, get_avci_header_format_string(i));
+    printf("                          or set <format> to 'all' for all formats listed above\n");
+    printf("                          The 512 bytes are extracted from <file> starting at <offset> bytes\n");
+    printf("                          and incrementing 512 bytes for each format in the list\n");
+    printf("  --ps-avcihead           Panasonic AVC-Intra sequence header data for Panasonic-compatible files that don't include the header data\n");
+    printf("                          These formats are supported:\n");
     for (i = 0; i < get_num_ps_avci_header_formats(); i++) {
         if (i == 0)
-            fprintf(stderr, "                              ");
+            printf("                              ");
         else if (i % 4 == 0)
-            fprintf(stderr, ",\n                              ");
+            printf(",\n                              ");
         else
-            fprintf(stderr, ", ");
-        fprintf(stderr, "%s", get_ps_avci_header_format_string(i));
+            printf(", ");
+        printf("%s", get_ps_avci_header_format_string(i));
     }
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  --track-map <expr>      Map input audio channels to output tracks\n");
-    fprintf(stderr, "                          The default is 'mono', except if --clip-wrap option is set for op1a it is 'singlemca'\n");
-    fprintf(stderr, "                          See below for details of the <expr> format\n");
-    fprintf(stderr, "  --dump-track-map        Dump the output audio track map to stderr.\n");
-    fprintf(stderr, "                          The dumps consists of a list output tracks, where each output track channel\n");
-    fprintf(stderr, "                          is shown as '<output track channel> <- <input channel>\n");
-    fprintf(stderr, "  --dump-track-map-exit   Same as --dump-track-map, but exit immediately afterwards\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/as11rdd9/op1a/rdd9/d10:\n");
-    fprintf(stderr, "    --head-fill <bytes>     Reserve minimum <bytes> at the end of the header metadata using a KLV Fill\n");
-    fprintf(stderr, "                            Add a 'K' suffix for kibibytes and 'M' for mibibytes\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02:\n");
-    fprintf(stderr, "    --mic-type <type>       Media integrity check type: 'md5' or 'none'. Default 'md5'\n");
-    fprintf(stderr, "    --mic-file              Calculate checksum for entire essence component file. Default is essence only\n");
-    fprintf(stderr, "    --shim-name <name>      Set ShimName element value in shim.xml file to <name>. Default is '%s'\n", DEFAULT_SHIM_NAME);
-    fprintf(stderr, "    --shim-id <id>          Set ShimID element value in shim.xml file to <id>. Default is '%s'\n", DEFAULT_SHIM_ID);
-    fprintf(stderr, "    --shim-annot <str>      Set AnnotationText element value in shim.xml file to <str>. Default is '%s'\n", DEFAULT_SHIM_ANNOTATION);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02/as11op1a/op1a/rdd9/as10:\n");
-    fprintf(stderr, "    --part <interval>       Video essence partition interval in frames, or (floating point) seconds with 's' suffix. Default single partition\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10:\n");
-    fprintf(stderr, "    --dm <fwork> <name> <value>    Set descriptive framework property. <fwork> is 'as11' or 'dpp'\n");
-    fprintf(stderr, "    --dm-file <fwork> <name>       Parse and set descriptive framework properties from text file <name>. <fwork> is 'as11' or 'dpp'\n");
-    fprintf(stderr, "    --seg <name>                   Parse and set segmentation data from text file <name>\n");
-    fprintf(stderr, "    --spec-id <id>                 Set the AS-11 specification identifier labels associated with <id>\n");
-    fprintf(stderr, "                                   The <id> is one of the following:\n");
-    fprintf(stderr, "                                       as11-x1 : AMWA AS-11 X1, delivery of finished UHD programs to Digital Production Partnership (DPP) broadcasters\n");
-    fprintf(stderr, "                                       as11-x2 : AMWA AS-11 X2, delivery of finished HD AVC Intra programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x3 : AMWA AS-11 X3, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x4 : AMWA AS-11 X4, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x5 : AMWA AS-11 X5, delivery of finished UHD TV Commericals and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
-    fprintf(stderr, "                                       as11-x6 : AMWA AS-11 X6, delivery of finished HD TV Commercials and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
-    fprintf(stderr, "                                       as11-x7 : AMWA AS-11 X7, delivery of finished SD D10 programs to a broadcaster or publisher\n");
-    fprintf(stderr, "                                       as11-x8 : AMWA AS-11 X8, delivery of finished HD (MPEG-2) programs to North American Broadcasters Association (NABA) broadcasters\n");
-    fprintf(stderr, "                                       as11-x9 : AMWA AS-11 X9, delivery of finished HD TV Programmes (AVC) to North American Broadcasters Association (NABA) broadcasters\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/op1a/rdd9/as10:\n");
-    fprintf(stderr, "    --out-start <offset>    Offset to start of first output frame, eg. pre-charge in MPEG-2 Long GOP\n");
-    fprintf(stderr, "    --out-end <offset>      Offset (positive value) from last frame to last output frame, eg. rollout in MPEG-2 Long GOP\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
-    fprintf(stderr, "    --seq-off <value>       Sound sample sequence offset. Default 0 for as11d10/d10 and not set (0) for as11op1a/op1a\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/op1a/rdd9/as10:\n");
-    fprintf(stderr, "    --single-pass           Write file in a single pass\n");
-    fprintf(stderr, "                            The header and body partitions will be incomplete\n");
-    fprintf(stderr, "    --file-md5              Calculate an MD5 checksum of the file. This requires writing in a single pass (--single-pass is assumed)\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a:\n");
-    fprintf(stderr, "    --no-tc-track           Don't create a timecode track in either the material or file source package\n");
-    fprintf(stderr, "    --min-part              Only use a header and footer MXF file partition. Use this for applications that don't support\n");
-    fprintf(stderr, "                            separate partitions for header metadata, index tables, essence container data and footer\n");
-    fprintf(stderr, "    --body-part             Create separate body partitions for essence data\n");
-    fprintf(stderr, "                            and don't create separate body partitions for index table segments\n");
-    fprintf(stderr, "    --repeat-index          Repeat the index table segments in the footer partition\n");
-    fprintf(stderr, "    --clip-wrap             Use clip wrapping for a single sound track\n");
-    fprintf(stderr, "    --mp-track-num          Use the material package track number property to define a track order. By default the track number is set to 0\n");
-    fprintf(stderr, "    --aes-3                 Use AES-3 audio mapping\n");
-    fprintf(stderr, "    --kag-size-512          Set KAG size to 512, instead of 1\n");
-    fprintf(stderr, "    --primary-package       Set the header metadata set primary package property to the top-level file source package\n");
-    fprintf(stderr, "    --index-follows         The index partition follows the essence partition, even when it is CBE essence\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/rdd9/d10:\n");
-    fprintf(stderr, "    --xml-scheme-id <id>    Set the XML payload scheme identifier associated with the following --embed-xml option.\n");
-    fprintf(stderr, "                            The <id> is one of the following:\n");
-    fprintf(stderr, "                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
-    fprintf(stderr, "                                * a UUID, formatted as a 'urn:uuid:...'or as 32 hexadecimal characters using a '.' or '-' seperator,\n");
-    fprintf(stderr, "                                * 'as11', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.04010000\n");
-    fprintf(stderr, "                            A default BMX scheme identifier is used if this option is not provided\n");
-    fprintf(stderr, "    --xml-lang <tag>        Set the RFC 5646 language tag associated with the the following --embed-xml option.\n");
-    fprintf(stderr, "                            Defaults to the xml:lang attribute in the root element or empty string if not present\n");
-    fprintf(stderr, "    --embed-xml <filename>  Embed the XML from <filename> using the approach specified in SMPTE RP 2057\n");
-    fprintf(stderr, "                            If the XML size is less than 64KB and uses UTF-8 or UTF-16 encoding (declared in\n");
-    fprintf(stderr, "                            the XML prolog) then the XML data is included in the header metadata. Otherwise\n");
-    fprintf(stderr, "                            a Generic Stream partition is used to hold the XML data.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/rdd9:\n");
-    fprintf(stderr, "    --ard-zdf-hdf           Use the ARD ZDF HDF profile\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11d10/d10:\n");
-    fprintf(stderr, "    --d10-mute <flags>      Indicate using a string of 8 '0' or '1' which sound channels should be muted. The lsb is the rightmost digit\n");
-    fprintf(stderr, "    --d10-invalid <flags>   Indicate using a string of 8 '0' or '1' which sound channels should be flagged invalid. The lsb is the rightmost digit\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as10:\n");
-    fprintf(stderr, "    --shim-name <name>      Shim name for AS10 (used for setting 'ShimName' metadata and setting video/sound parameters' checks)\n");
-    fprintf(stderr, "                            list of known shims: %s\n", get_as10_shim_names().c_str());
-    fprintf(stderr, "    --dm-file as10 <name>   Parse and set descriptive framework properties from text file <name>\n");
-    fprintf(stderr, "                            N.B. 'ShimName' is the only mandatary property of AS10 metadata set\n");
-    fprintf(stderr, "    --dm as10 <name> <value>    Set descriptive framework property\n");
-    fprintf(stderr, "    --pass-dm               Copy descriptive metadata from the input file. The metadata can be overidden by other options\n");
-    fprintf(stderr, "    --mpeg-checks [<name>]  Enable AS-10 compliancy checks. The file <name> is optional and contains expected descriptor values\n");
-    fprintf(stderr, "    --loose-checks          Don't stop processing on detected compliancy violations\n");
-    fprintf(stderr, "    --print-checks          Print default values of mpeg descriptors and report on descriptors either found in mpeg headers or copied from mxf headers\n");
-    fprintf(stderr, "    --max-same-warnings <value>  Max same violations warnings logged, default 3\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
-    fprintf(stderr, "    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
-    fprintf(stderr, "    --fp-uid <umid>         Set the File Package UID. Autogenerated by default\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  avid:\n");
-    fprintf(stderr, "    --project <name>        Set the Avid project name\n");
-    fprintf(stderr, "    --tape <name>           Source tape name\n");
-    fprintf(stderr, "    --import <name>         Source import name. <name> is one of the following:\n");
-    fprintf(stderr, "                              - a file URL starting with 'file://'\n");
-    fprintf(stderr, "                              - an absolute Windows (starts with '[A-Z]:') or *nix (starts with '/') filename\n");
-    fprintf(stderr, "                              - a relative filename, which will be converted to an absolute filename\n");
-    fprintf(stderr, "    --aux <hh:mm:sscff>     Set up to 5 auxiliary start timecodes. Multiple timecodes are separated by commas e.g. --aux 15:02:15:23,09:37:08:10\n");
-    fprintf(stderr, "                            The c character in the pattern should be ':' for non-drop frame; any other character indicates drop frame\n");
-    fprintf(stderr, "    --comment <string>      Add 'Comments' user comment to the MaterialPackage\n");
-    fprintf(stderr, "    --desc <string>         Add 'Descript' user comment to the MaterialPackage\n");
-    fprintf(stderr, "    --tag <name> <value>    Add <name> user comment to the MaterialPackage. Option can be used multiple times\n");
-    fprintf(stderr, "    --locator <position> <comment> <color>\n");
-    fprintf(stderr, "                            Add locator at <position> (in frame rate units) with <comment> and <color>\n");
-    fprintf(stderr, "                            <position> format is o?hh:mm:sscff, where the optional 'o' indicates it is an offset\n");
-    fprintf(stderr, "    --umid-type <type>      Set the UMID type that is generated for the Package UID properties.\n");
-    fprintf(stderr, "                            The default <type> is 'aafsdk'.\n");
-    fprintf(stderr, "                            The <type> is one of the following:\n");
-    fprintf(stderr, "                              uuid       : UUID generation method\n");
-    fprintf(stderr, "                              aafsdk     : same method as implemented in the AAF SDK\n");
-    fprintf(stderr, "                                           This type is required to be compatible with some older Avid product versions\n");
-    fprintf(stderr, "                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
-    fprintf(stderr, "                              old-aafsdk : same method as implemented in revision 1.47 of AAF/ref-impl/src/impl/AAFUtils.c in the AAF SDK\n");
-    fprintf(stderr, "                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
-    fprintf(stderr, "    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
-    fprintf(stderr, "    --mp-created <tstamp>   Set the Material Package creation date. Default is 'now'\n");
-    fprintf(stderr, "    --psp-uid <umid>        Set the tape/import Source Package UID. Autogenerated by default\n");
-    fprintf(stderr, "    --psp-created <tstamp>  Set the tape/import Source Package creation date. Default is 'now'\n");
-    fprintf(stderr, "    --allow-no-avci-head    Allow inputs with no AVCI header (512 bytes, sequence and picture parameter sets)\n");
-    fprintf(stderr, "    --avid-gf               Use the Avid growing file flavour\n");
-    fprintf(stderr, "    --avid-gf-dur <dur>     Set the duration which should be shown whilst the file is growing\n");
-    fprintf(stderr, "                            Avid will show 'Capture in Progress' when this option is used\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/avid:\n");
-    fprintf(stderr, "    --force-no-avci-head    Strip AVCI header (512 bytes, sequence and picture parameter sets) if present\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  wave:\n");
-    fprintf(stderr, "    --orig <name>           Set originator in the output Wave bext chunk. Default '%s'\n", DEFAULT_BEXT_ORIGINATOR);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02/op1a/as11op1a:\n");
-    fprintf(stderr, "    --use-avc-subdesc       Use the AVC sub-descriptor rather than the MPEG video descriptor for AVC-Intra tracks\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  op1a/as11op1a/rdd9:\n");
-    fprintf(stderr, "    --audio-layout <label>  Set the Wave essence descriptor channel assignment label which identifies the audio layout mode in operation\n");
-    fprintf(stderr, "                            The <label> is one of the following:\n");
-    fprintf(stderr, "                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
-    fprintf(stderr, "                                * 'as11-mode-0', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02010000,\n");
-    fprintf(stderr, "                                * 'as11-mode-1', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02020000,\n");
-    fprintf(stderr, "                                * 'as11-mode-2', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02030000\n");
-    fprintf(stderr, "                                * 'imf', which corresponds to urn:smpte:ul:060e2b34.0401010d.04020210.04010000\n");
-    fprintf(stderr, "    --track-mca-labels <scheme> <file>  Insert audio labels defined in <file>. The 'as11' <scheme> will add an override and otherwise <scheme> is ignored\n");
-    fprintf(stderr, "                                        The format of <file> is described in bmx/docs/mca_labels_format.md\n");
-    fprintf(stderr, "                                        All tag symbols registered in the bmx code are available for use\n");
-    fprintf(stderr, "                                        The 'as11' <scheme> will change the label associated with the 'chVIN' tag symbol to use the 'Visually Impaired Narrative' tag name, i.e. without a '-'\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Input Options (must precede the input to which it applies):\n");
-    fprintf(stderr, "  -a <n:d>                Image aspect ratio. Default parsed from essence or 16:9\n");
-    fprintf(stderr, "  --bsar                  Set image aspect ratio in video bitstream. Currently supports D-10 essence types only\n");
-    fprintf(stderr, "  --afd <value>           Active Format Descriptor 4-bit code from table 1 in SMPTE ST 2016-1. Default not set\n");
-    fprintf(stderr, "  -c <depth>              Component depth for uncompressed/DV100/RDD-36 video. Either 8 or 10. Default parsed, 8 for uncompressed/DV100 and 10 for RDD-36\n");
-    fprintf(stderr, "  --height <value>        Height of input uncompressed video data. Default is the production aperture height, except for PAL (592) and NTSC (496)\n");
-    fprintf(stderr, "  --signal-std  <value>   Set the video signal standard. The <value> is one of the following:\n");
-    fprintf(stderr, "                              'none', 'bt601', 'bt1358', 'st347', 'st274', 'st296', 'st349', 'st428'\n");
-    fprintf(stderr, "  --frame-layout <value>  Set the video frame layout. The <value> is one of the following:\n");
-    fprintf(stderr, "                              'fullframe', 'separatefield', 'singlefield', 'mixedfield', 'segmentedframe'\n");
-    fprintf(stderr, "  --field-dom <value>     Set which field is first in temporal order. The <value> is 1 or 2\n");
-    fprintf(stderr, "  --transfer-ch <value>   Set the transfer characteristic label\n");
-    fprintf(stderr, "                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
-    fprintf(stderr, "                              'bt470', 'bt709', 'st240', 'st274', 'bt1361', 'linear', 'dcdm',\n");
-    fprintf(stderr, "                              'iec61966', 'bt2020', 'st2084', 'hlg'\n");
-    fprintf(stderr, "  --coding-eq <value>     Set the coding equations label\n");
-    fprintf(stderr, "                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
-    fprintf(stderr, "                              'bt601', 'bt709', 'st240', 'ycgco', 'gbr', 'bt2020'\n");
-    fprintf(stderr, "  --color-prim <value>    Set the color primaries label\n");
-    fprintf(stderr, "                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
-    fprintf(stderr, "                              'st170', 'bt470', 'bt709', 'bt2020', 'dcdm', 'p3'\n");
-    fprintf(stderr, "  --color-siting <value>  Set the color siting. The <value> is one of the following:\n");
-    fprintf(stderr, "                              'cositing', 'horizmp', '3tap', 'quincunx', 'bt601', 'linealt', 'vertmp', 'unknown'\n");
-    fprintf(stderr, "                              (Note that 'bt601' is deprecated in SMPTE ST 377-1. Use 'cositing' instead)\n");
-    fprintf(stderr, "  --black-level <value>   Set the CDCI black reference level\n");
-    fprintf(stderr, "  --white-level <value>   Set the CDCI white reference level\n");
-    fprintf(stderr, "  --color-range <value>   Set the CDCI color range\n");
-    fprintf(stderr, "  --comp-max-ref <value>  Set the RGBA component maximum reference level\n");
-    fprintf(stderr, "  --comp-min-ref <value>  Set the RGBA component minimum reference level\n");
-    fprintf(stderr, "  --scan-dir <value>      Set the RGBA scanning direction\n");
-    fprintf(stderr, "  --display-primaries <value>    Set the mastering display primaries.\n");
-    fprintf(stderr, "                                 The <value> is an array of 6 unsigned integers separated by a ','.\n");
-    fprintf(stderr, "  --display-white-point <value>  Set the mastering display white point chromaticity.\n");
-    fprintf(stderr, "                                 The <value> is an array of 2 unsigned integers separated by a ','.\n");
-    fprintf(stderr, "  --display-max-luma <value>     Set the mastering display maximum luminance.\n");
-    fprintf(stderr, "  --display-min-luma <value>     Set the mastering display minimum luminance.\n");
-    fprintf(stderr, "  --rdd36-opaque          Treat RDD-36 4444 or 4444 XQ as opaque by omitting the Alpha Sample Depth property\n");
-    fprintf(stderr, "  --active-width          Set the Active Width of the active area rectangle\n");
-    fprintf(stderr, "  --active-height         Set the Active Height of the active area rectangle\n");
-    fprintf(stderr, "  --active-x-offset       Set the Active X Offset of the active area rectangle\n");
-    fprintf(stderr, "  --active-y-offset       Set the Active Y Offset of the active area rectangle\n");
-    fprintf(stderr, "  --display-f2-offset     Set the default Display F2 Offset if none is extracted from the essence\n");
-    fprintf(stderr, "  --center-cut-4-3        Add the Alternative Center Cut 4:3\n");
-    fprintf(stderr, "  --center-cut-14-9       Add the Alternative Center Cut 14:9\n");
-    fprintf(stderr, "  -s <bps>                Audio sampling rate numerator for raw pcm. Default %d\n", DEFAULT_SAMPLING_RATE.numerator);
-    fprintf(stderr, "  -q <bps>                Audio quantization bits per sample for raw pcm. Either 16 or 24. Default 16\n");
-    fprintf(stderr, "  --audio-chan <count>    Audio channel count for raw pcm. Default 1\n");
-    fprintf(stderr, "  --locked <bool>         Indicate whether the number of audio samples is locked to the video. Either true or false. Default not set\n");
-    fprintf(stderr, "  --audio-ref <level>     Audio reference level, number of dBm for 0VU. Default not set\n");
-    fprintf(stderr, "  --dial-norm <value>     Gain to be applied to normalize perceived loudness of the clip. Default not set\n");
-    fprintf(stderr, "  --ref-image-edit-rate <rate>     Override or set the Reference Image Edit Rate\n");
-    fprintf(stderr, "                                   The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
-    fprintf(stderr, "  --ref-audio-align-level <value>  Override or set the Reference Audio Alignment Level\n");
-    fprintf(stderr, "  --anc-const <size>      Set the constant ANC data frame <size>\n");
-    fprintf(stderr, "  --vbi-const <size>      Set the constant VBI data frame <size>\n");
-    fprintf(stderr, "  --off <bytes>           Skip <bytes> at the start of the next input/track's file\n");
-    fprintf(stderr, "  --maxlen <bytes>        Maximum number of essence data bytes to read from next input/track's file\n");
-    fprintf(stderr, "  --klv <key>             Essence data is read from the KLV data in the next input/track's file\n");
-    fprintf(stderr, "                          <key> should have one of the following values:\n");
-    fprintf(stderr, "                            - 's', which means the first 16 bytes, at file position 0 or --off byte offset, are taken to be the Key\n");
-    fprintf(stderr, "                            - optional '0x' followed by 8 hexadecimal characters which represents the 4-byte track number part of a generic container essence Key\n");
-    fprintf(stderr, "                            - 32 hexadecimal characters representing a 16-byte Key\n");
-    fprintf(stderr, "  --fill-pattern-gaps     Fill gaps in a numbered sequence pattern of raw files by repeating the contents of the file at the start of a gap\n");
-    fprintf(stderr, "  --track-num <num>       Set the output track number. Default track number equals last track number of same picture/sound type + 1\n");
-    fprintf(stderr, "                          For as11d10/d10 the track number must be > 0 and <= 8 because the AES-3 channel index equals track number - 1\n");
-    fprintf(stderr, "  --avci-guess <i/p>      Guess interlaced ('i') or progressive ('p') AVC-Intra when using the --avci option with 1080p25/i50 or 1080p30/i60\n");
-    fprintf(stderr, "                          The default guess uses the H.264 frame_mbs_only_flag field\n");
-    fprintf(stderr, "  --fixed-size            Set to indicate that the d10 frames have a fixed size and therefore do not need to be parsed after the first frame\n");
-    fprintf(stderr, "  --vc2-mode <mode>       Set the mode that determines how the VC-2 data is wrapped\n");
-    fprintf(stderr, "                          <mode> is one of the following integer values:\n");
-    fprintf(stderr, "                            0: Passthrough input, but add a sequence header if not present, remove duplicate/redundant sequence headers\n");
-    fprintf(stderr, "                               and fix any incorrect parse info offsets and picture numbers\n");
-    fprintf(stderr, "                            1: (default) Same as 0, but remove auxiliary and padding data units and complete the sequence in each frame\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  as02:\n");
-    fprintf(stderr, "    --trk-out-start <offset>   Offset to start of first output frame, eg. pre-charge in MPEG-2 Long GOP\n");
-    fprintf(stderr, "    --trk-out-end <offset>     Offset (positive value) from last frame to last output frame, eg. rollout in MPEG-2 Long GOP\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Inputs:\n");
-    fprintf(stderr, "  --dv <name>             Raw DV video input file\n");
-    fprintf(stderr, "  --iecdv25 <name>        Raw IEC DV25 video input file\n");
-    fprintf(stderr, "  --dvbased25 <name>      Raw DV-Based DV25 video input file\n");
-    fprintf(stderr, "  --dv50 <name>           Raw DV50 video input file\n");
-    fprintf(stderr, "  --dv100_1080i <name>    Raw DV100 1080i video input file\n");
-    fprintf(stderr, "  --dv100_1080p <name>    Raw DV100 1080p video input file\n");
-    fprintf(stderr, "  --dv100_720p <name>     Raw DV100 720p video input file\n");
-    fprintf(stderr, "  --d10 <name>            Raw D10 video input file\n");
-    fprintf(stderr, "  --d10_30 <name>         Raw D10 30Mbps video input file\n");
-    fprintf(stderr, "  --d10_40 <name>         Raw D10 40Mbps video input file\n");
-    fprintf(stderr, "  --d10_50 <name>         Raw D10 50Mbps video input file\n");
-    fprintf(stderr, "  --avci <name>           Raw AVC-Intra video input file. See also --avci-guess option\n");
-    fprintf(stderr, "  --avci200_1080i <name>  Raw AVC-Intra 200 1080i video input file\n");
-    fprintf(stderr, "  --avci200_1080p <name>  Raw AVC-Intra 200 1080p video input file\n");
-    fprintf(stderr, "  --avci200_720p <name>   Raw AVC-Intra 200 720p video input file\n");
-    fprintf(stderr, "  --avci100_1080i <name>  Raw AVC-Intra 100 1080i video input file\n");
-    fprintf(stderr, "  --avci100_1080p <name>  Raw AVC-Intra 100 1080p video input file\n");
-    fprintf(stderr, "  --avci100_720p <name>   Raw AVC-Intra 100 720p video input file\n");
-    fprintf(stderr, "  --avci50_1080i <name>   Raw AVC-Intra 50 1080i video input file\n");
-    fprintf(stderr, "  --avci50_1080p <name>   Raw AVC-Intra 50 1080p video input file\n");
-    fprintf(stderr, "  --avci50_720p <name>    Raw AVC-Intra 50 720p video input file\n");
-    fprintf(stderr, "  --avc <name>                 Raw AVC video input file\n");
-    fprintf(stderr, "  --avc_baseline <name>        Raw AVC Baseline profile video input file\n");
-    fprintf(stderr, "  --avc_constr_baseline <name> Raw AVC Constrained Baseline profile video input file\n");
-    fprintf(stderr, "  --avc_main <name>            Raw AVC Main profile video input file\n");
-    fprintf(stderr, "  --avc_extended <name>        Raw AVC Extended profile video input file\n");
-    fprintf(stderr, "  --avc_high <name>            Raw AVC High profile video input file\n");
-    fprintf(stderr, "  --avc_high_10 <name>         Raw AVC High 10 profile video input file\n");
-    fprintf(stderr, "  --avc_high_422 <name>        Raw AVC High 422 profile video input file\n");
-    fprintf(stderr, "  --avc_high_444 <name>        Raw AVC High 444 profile video input file\n");
-    fprintf(stderr, "  --avc_high_10_intra <name>   Raw AVC High 10 Intra profile video input file\n");
-    fprintf(stderr, "  --avc_high_422_intra <name>  Raw AVC High 422 Intra profile video input file\n");
-    fprintf(stderr, "  --avc_high_444_intra <name>  Raw AVC High 444 Intra profile video input file\n");
-    fprintf(stderr, "  --avc_cavlc_444 <name>       Raw AVC CAVLC 444 profile video input file\n");
-    fprintf(stderr, "  --unc <name>            Raw uncompressed SD UYVY 422 video input file\n");
-    fprintf(stderr, "  --unc_1080i <name>      Raw uncompressed HD 1080i UYVY 422 video input file\n");
-    fprintf(stderr, "  --unc_1080p <name>      Raw uncompressed HD 1080p UYVY 422 video input file\n");
-    fprintf(stderr, "  --unc_720p <name>       Raw uncompressed HD 720p UYVY 422 video input file\n");
-    fprintf(stderr, "  --unc_3840 <name>       Raw uncompressed UHD 3840x2160 UYVY 422 video input file\n");
-    fprintf(stderr, "  --avid_alpha <name>               Raw Avid alpha component SD video input file\n");
-    fprintf(stderr, "  --avid_alpha_1080i <name>         Raw Avid alpha component HD 1080i video input file\n");
-    fprintf(stderr, "  --avid_alpha_1080p <name>         Raw Avid alpha component HD 1080p video input file\n");
-    fprintf(stderr, "  --avid_alpha_720p <name>          Raw Avid alpha component HD 720p video input file\n");
-    fprintf(stderr, "  --mpeg2lg <name>                  Raw MPEG-2 Long GOP video input file\n");
-    fprintf(stderr, "  --mpeg2lg_422p_ml_576i <name>     Raw MPEG-2 Long GOP 422P@ML 576i video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_ml_576i <name>       Raw MPEG-2 Long GOP MP@ML 576i video input file\n");
-    fprintf(stderr, "  --mpeg2lg_422p_hl_1080i <name>    Raw MPEG-2 Long GOP 422P@HL 1080i video input file\n");
-    fprintf(stderr, "  --mpeg2lg_422p_hl_1080p <name>    Raw MPEG-2 Long GOP 422P@HL 1080p video input file\n");
-    fprintf(stderr, "  --mpeg2lg_422p_hl_720p <name>     Raw MPEG-2 Long GOP 422P@HL 720p video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_hl_1920_1080i <name> Raw MPEG-2 Long GOP MP@HL 1920x1080i video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_hl_1920_1080p <name> Raw MPEG-2 Long GOP MP@HL 1920x1080p video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_hl_1440_1080i <name> Raw MPEG-2 Long GOP MP@HL 1440x1080i video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_hl_1440_1080p <name> Raw MPEG-2 Long GOP MP@HL 1440x1080p video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_hl_720p <name>       Raw MPEG-2 Long GOP MP@HL 720p video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_h14_1080i <name>     Raw MPEG-2 Long GOP MP@H14 1080i video input file\n");
-    fprintf(stderr, "  --mpeg2lg_mp_h14_1080p <name>     Raw MPEG-2 Long GOP MP@H14 1080p video input file\n");
-    fprintf(stderr, "  --mjpeg21 <name>        Raw Avid MJPEG 2:1 video input file\n");
-    fprintf(stderr, "  --mjpeg31 <name>        Raw Avid MJPEG 3:1 video input file\n");
-    fprintf(stderr, "  --mjpeg101 <name>       Raw Avid MJPEG 10:1 video input file\n");
-    fprintf(stderr, "  --mjpeg201 <name>       Raw Avid MJPEG 20:1 video input file\n");
-    fprintf(stderr, "  --mjpeg41m <name>       Raw Avid MJPEG 4:1m video input file\n");
-    fprintf(stderr, "  --mjpeg101m <name>      Raw Avid MJPEG 10:1m video input file\n");
-    fprintf(stderr, "  --mjpeg151s <name>      Raw Avid MJPEG 15:1s video input file\n");
-    fprintf(stderr, "  --rdd36_422_proxy <name>   Raw SMPTE RDD-36 (ProRes) 4:2:2 Proxy profile input file\n");
-    fprintf(stderr, "  --rdd36_422_lt <name>      Raw SMPTE RDD-36 (ProRes) 4:2:2 LT profile input file\n");
-    fprintf(stderr, "  --rdd36_422 <name>         Raw SMPTE RDD-36 (ProRes) 4:2:2 profile input file\n");
-    fprintf(stderr, "  --rdd36_422_hq <name>      Raw SMPTE RDD-36 (ProRes) 4:2:2 HQ profile input file\n");
-    fprintf(stderr, "  --rdd36_4444 <name>        Raw SMPTE RDD-36 (ProRes) 4:4:4:4 profile input file\n");
-    fprintf(stderr, "  --rdd36_4444_xq <name>     Raw SMPTE RDD-36 (ProRes) 4:4:4:4 XQ profile input file\n");
-    fprintf(stderr, "  --j2c_cdci <name|j2cpattern>  Raw JPEG 2000 (ISO/IEC 15444-1) codestream representing components (e.g. YCbCr) described by a MXF CDCI descriptor\n");
-    fprintf(stderr, "                                If a '%%' is in the value then it is assumed to be a <j2cpattern> for a sequence of files, each containing a single frame\n");
-    fprintf(stderr, "                                See Notes below for a detailed description of <j2cpattern>\n");
-    fprintf(stderr, "  --j2c_rgba <name|j2cpattern>  Raw JPEG 2000 (ISO/IEC 15444-1) codestream representing components (e.g. RGB) described by a MXF RGBA descriptor\n");
-    fprintf(stderr, "                                If a '%%' is in the value then it is assumed to be a <j2cpattern> for a sequence of files, each containing a single frame\n");
-    fprintf(stderr, "                                See Notes below for a detailed description of <j2cpattern>\n");
-    fprintf(stderr, "  --vc2 <name>            Raw VC2 input file\n");
-    fprintf(stderr, "  --vc3 <name>            Raw VC3/DNxHD input file\n");
-    fprintf(stderr, "  --vc3_1080p_1235 <name> Raw VC3/DNxHD 1920x1080p 220/185/175 Mbps 10bit input file\n");
-    fprintf(stderr, "  --vc3_1080p_1237 <name> Raw VC3/DNxHD 1920x1080p 145/120/115 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080p_1238 <name> Raw VC3/DNxHD 1920x1080p 220/185/175 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080i_1241 <name> Raw VC3/DNxHD 1920x1080i 220/185 Mbps 10bit input file\n");
-    fprintf(stderr, "  --vc3_1080i_1242 <name> Raw VC3/DNxHD 1920x1080i 145/120 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080i_1243 <name> Raw VC3/DNxHD 1920x1080i 220/185 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080i_1244 <name> Raw VC3/DNxHD 1920x1080i 145/120 Mbps input file\n");
-    fprintf(stderr, "  --vc3_720p_1250 <name>  Raw VC3/DNxHD 1280x720p 220/185/110/90 Mbps 10bit input file\n");
-    fprintf(stderr, "  --vc3_720p_1251 <name>  Raw VC3/DNxHD 1280x720p 220/185/110/90 Mbps input file\n");
-    fprintf(stderr, "  --vc3_720p_1252 <name>  Raw VC3/DNxHD 1280x720p 220/185/110/90 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080p_1253 <name> Raw VC3/DNxHD 1920x1080p 45/36 Mbps input file\n");
-    fprintf(stderr, "  --vc3_720p_1258 <name>  Raw VC3/DNxHD 1280x720p 45 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080p_1259 <name> Raw VC3/DNxHD 1920x1080p 85 Mbps input file\n");
-    fprintf(stderr, "  --vc3_1080i_1260 <name> Raw VC3/DNxHD 1920x1080i 85 Mbps input file\n");
-    fprintf(stderr, "  --pcm <name>            Raw PCM audio input file\n");
-    fprintf(stderr, "  --wave <name>           Wave PCM audio input file\n");
-    fprintf(stderr, "  --anc <name>            Raw ST 436 Ancillary data. Currently requires the --anc-const option\n");
-    fprintf(stderr, "  --vbi <name>            Raw ST 436 Vertical Blanking Interval data. Currently requires the --vbi-const option\n");
-    fprintf(stderr, "  --tt <manifest>         Manifest file containing Timed Text metadata\n");
-    fprintf(stderr, "\n\n");
-    fprintf(stderr, "Notes:\n");
-    fprintf(stderr, " - filename pattern: Clip types producing a single output file may use a filename pattern with variables that get substituted\n");
-    fprintf(stderr, "                     Pattern variables start with a '{' and end with a '}'. E.g. 'output_{type}_{fp_uuid}.mxf'\n");
-    fprintf(stderr, "                     The following variables are available:\n");
-    fprintf(stderr, "                       - {type}: Is replaced with the name for video, audio, data or mixed essence types\n");
-    fprintf(stderr, "                                 See the --ess-type-names option for the default names and use the option to change them\n");
-    fprintf(stderr, "                       - {mp_uuid}: The UUID material number in a material package UMID\n");
-    fprintf(stderr, "                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
-    fprintf(stderr, "                       - {mp_umid}: The material package UMID\n");
-    fprintf(stderr, "                       - {fp_uuid}: The UUID material number in a file source package UMID\n");
-    fprintf(stderr, "                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
-    fprintf(stderr, "                       - {fp_umid}: The file source package UMID\n");
-    fprintf(stderr, " - <umid> format is 64 hexadecimal characters and any '.' and '-' characters are ignored\n");
-    fprintf(stderr, " - <uuid> format is 32 hexadecimal characters and any '.' and '-' characters are ignored\n");
-    fprintf(stderr, " - <tstamp> format is YYYY-MM-DDThh:mm:ss:qm where qm is in units of 1/250th second\n");
-    fprintf(stderr, " - <j2cpattern>: Each file name must include an integer frame number in the sequence.\n");
-    fprintf(stderr, "                 <j2cpattern> is a file path that must contain a single '%%d' where the frame number appears in the name.\n");
-    fprintf(stderr, "                 <j2cpattern> must not contain any other '%%' characters.\n");
-    fprintf(stderr, "                 If --fill-pattern-gaps option is used then gaps in frame numbers are filled by repeating the previous frame.\n");
-    fprintf(stderr, "                 Example: 'inputs/frame_%%d.j2c' for input files `inputs/frame_00001.j2c' etc..\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " The track mapping <expr> format is one of the following:\n");
-    fprintf(stderr, "     'mono'     : each input audio channel is mapped to a single-channel output track\n");
-    fprintf(stderr, "     'stereo'   : input audio channels are paired to stereo-channel output tracks\n");
-    fprintf(stderr, "                  A silence channel is added to the last output track if the channel count is odd\n");
-    fprintf(stderr, "     'singlemca': all input audio channels are mapped to a single multi-channel output track\n");
-    fprintf(stderr, "     <pattern>  : a pattern defining how input channels map to output track channels - see below\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, " The track mapping <pattern> specifies how input audio channels are mapped to output track channels\n");
-    fprintf(stderr, " A <pattern> consists of a list of <group>s separated by a ';'.\n");
-    fprintf(stderr, " A <group> starts with an optional 'm', followed by a list of <element> separated by a ','.\n");
-    fprintf(stderr, "   An 'm' indicates that each channel in the <group> is mapped to separate single-channel output track.\n");
-    fprintf(stderr, "   If an 'm' is not present then the channels are mapped to a single output track.\n");
-    fprintf(stderr, " A <element> is either a <channel>, <range>, <silence> or <remainder>.\n");
-    fprintf(stderr, " A <channel> is an input channel number starting from 0.\n");
-    fprintf(stderr, "   The input channel number is the number derived from the input track order reported by mxf2raw for the\n");
-    fprintf(stderr, "   input files in the same order and including any --disable input options. Each channel in a track\n");
-    fprintf(stderr, "   contributes 1 to the overall channel number.\n");
-    fprintf(stderr, " A <range> is 2 <channel>s separated by a '-' and includes all channels starting with the first number\n");
-    fprintf(stderr, "   and ending with the last number.\n");
-    fprintf(stderr, " A <silence> is 's' followed by a <count> and results in <count> silence channels added to the output track.\n");
-    fprintf(stderr, " A <remainder> is 'x', and results in all remaining channels being added to the output track.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Here are some <pattern> examples:\n");
-    fprintf(stderr, "    'mx'     : equivalent to 'mono'\n");
-    fprintf(stderr, "    '0,1;x'  : the first 2 channels mapped to a stereo output track and all remaining channels mapped\n");
-    fprintf(stderr, "               to a single multi-channel track\n");
-    fprintf(stderr, "    '2-7;0,1': 6 channel output track followed by a 2 channel output track\n");
-    fprintf(stderr, "    '0,1,s2' : 2 input channels plus 2 silence channels mapped to a single output track\n");
+    printf("\n");
+    printf("  --track-map <expr>      Map input audio channels to output tracks\n");
+    printf("                          The default is 'mono', except if --clip-wrap option is set for op1a it is 'singlemca'\n");
+    printf("                          See below for details of the <expr> format\n");
+    printf("  --dump-track-map        Dump the output audio track map to stderr.\n");
+    printf("                          The dumps consists of a list output tracks, where each output track channel\n");
+    printf("                          is shown as '<output track channel> <- <input channel>\n");
+    printf("  --dump-track-map-exit   Same as --dump-track-map, but exit immediately afterwards\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/as11rdd9/op1a/rdd9/d10:\n");
+    printf("    --head-fill <bytes>     Reserve minimum <bytes> at the end of the header metadata using a KLV Fill\n");
+    printf("                            Add a 'K' suffix for kibibytes and 'M' for mibibytes\n");
+    printf("\n");
+    printf("  as02:\n");
+    printf("    --mic-type <type>       Media integrity check type: 'md5' or 'none'. Default 'md5'\n");
+    printf("    --mic-file              Calculate checksum for entire essence component file. Default is essence only\n");
+    printf("    --shim-name <name>      Set ShimName element value in shim.xml file to <name>. Default is '%s'\n", DEFAULT_SHIM_NAME);
+    printf("    --shim-id <id>          Set ShimID element value in shim.xml file to <id>. Default is '%s'\n", DEFAULT_SHIM_ID);
+    printf("    --shim-annot <str>      Set AnnotationText element value in shim.xml file to <str>. Default is '%s'\n", DEFAULT_SHIM_ANNOTATION);
+    printf("\n");
+    printf("  as02/as11op1a/op1a/rdd9/as10:\n");
+    printf("    --part <interval>       Video essence partition interval in frames, or (floating point) seconds with 's' suffix. Default single partition\n");
+    printf("\n");
+    printf("  as11op1a/as11d10:\n");
+    printf("    --dm <fwork> <name> <value>    Set descriptive framework property. <fwork> is 'as11' or 'dpp'\n");
+    printf("    --dm-file <fwork> <name>       Parse and set descriptive framework properties from text file <name>. <fwork> is 'as11' or 'dpp'\n");
+    printf("    --seg <name>                   Parse and set segmentation data from text file <name>\n");
+    printf("    --spec-id <id>                 Set the AS-11 specification identifier labels associated with <id>\n");
+    printf("                                   The <id> is one of the following:\n");
+    printf("                                       as11-x1 : AMWA AS-11 X1, delivery of finished UHD programs to Digital Production Partnership (DPP) broadcasters\n");
+    printf("                                       as11-x2 : AMWA AS-11 X2, delivery of finished HD AVC Intra programs to a broadcaster or publisher\n");
+    printf("                                       as11-x3 : AMWA AS-11 X3, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
+    printf("                                       as11-x4 : AMWA AS-11 X4, delivery of finished HD AVC Long GOP programs to a broadcaster or publisher\n");
+    printf("                                       as11-x5 : AMWA AS-11 X5, delivery of finished UHD TV Commericals and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
+    printf("                                       as11-x6 : AMWA AS-11 X6, delivery of finished HD TV Commercials and Promotions to UK Digital Production Partnership (DPP) broadcasters\n");
+    printf("                                       as11-x7 : AMWA AS-11 X7, delivery of finished SD D10 programs to a broadcaster or publisher\n");
+    printf("                                       as11-x8 : AMWA AS-11 X8, delivery of finished HD (MPEG-2) programs to North American Broadcasters Association (NABA) broadcasters\n");
+    printf("                                       as11-x9 : AMWA AS-11 X9, delivery of finished HD TV Programmes (AVC) to North American Broadcasters Association (NABA) broadcasters\n");
+    printf("\n");
+    printf("  as11op1a/op1a/rdd9/as10:\n");
+    printf("    --out-start <offset>    Offset to start of first output frame, eg. pre-charge in MPEG-2 Long GOP\n");
+    printf("    --out-end <offset>      Offset (positive value) from last frame to last output frame, eg. rollout in MPEG-2 Long GOP\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
+    printf("    --seq-off <value>       Sound sample sequence offset. Default 0 for as11d10/d10 and not set (0) for as11op1a/op1a\n");
+    printf("\n");
+    printf("  as11op1a/op1a/rdd9/as10:\n");
+    printf("    --single-pass           Write file in a single pass\n");
+    printf("                            The header and body partitions will be incomplete\n");
+    printf("    --file-md5              Calculate an MD5 checksum of the file. This requires writing in a single pass (--single-pass is assumed)\n");
+    printf("\n");
+    printf("  op1a:\n");
+    printf("    --no-tc-track           Don't create a timecode track in either the material or file source package\n");
+    printf("    --min-part              Only use a header and footer MXF file partition. Use this for applications that don't support\n");
+    printf("                            separate partitions for header metadata, index tables, essence container data and footer\n");
+    printf("    --body-part             Create separate body partitions for essence data\n");
+    printf("                            and don't create separate body partitions for index table segments\n");
+    printf("    --repeat-index          Repeat the index table segments in the footer partition\n");
+    printf("    --clip-wrap             Use clip wrapping for a single sound track\n");
+    printf("    --mp-track-num          Use the material package track number property to define a track order. By default the track number is set to 0\n");
+    printf("    --aes-3                 Use AES-3 audio mapping\n");
+    printf("    --kag-size-512          Set KAG size to 512, instead of 1\n");
+    printf("    --primary-package       Set the header metadata set primary package property to the top-level file source package\n");
+    printf("    --index-follows         The index partition follows the essence partition, even when it is CBE essence\n");
+    printf("\n");
+    printf("  op1a/rdd9/d10:\n");
+    printf("    --xml-scheme-id <id>    Set the XML payload scheme identifier associated with the following --embed-xml option.\n");
+    printf("                            The <id> is one of the following:\n");
+    printf("                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
+    printf("                                * a UUID, formatted as a 'urn:uuid:...'or as 32 hexadecimal characters using a '.' or '-' seperator,\n");
+    printf("                                * 'as11', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.04010000\n");
+    printf("                            A default BMX scheme identifier is used if this option is not provided\n");
+    printf("    --xml-lang <tag>        Set the RFC 5646 language tag associated with the the following --embed-xml option.\n");
+    printf("                            Defaults to the xml:lang attribute in the root element or empty string if not present\n");
+    printf("    --embed-xml <filename>  Embed the XML from <filename> using the approach specified in SMPTE RP 2057\n");
+    printf("                            If the XML size is less than 64KB and uses UTF-8 or UTF-16 encoding (declared in\n");
+    printf("                            the XML prolog) then the XML data is included in the header metadata. Otherwise\n");
+    printf("                            a Generic Stream partition is used to hold the XML data.\n");
+    printf("\n");
+    printf("  op1a/rdd9:\n");
+    printf("    --ard-zdf-hdf           Use the ARD ZDF HDF profile\n");
+    printf("\n");
+    printf("  as11d10/d10:\n");
+    printf("    --d10-mute <flags>      Indicate using a string of 8 '0' or '1' which sound channels should be muted. The lsb is the rightmost digit\n");
+    printf("    --d10-invalid <flags>   Indicate using a string of 8 '0' or '1' which sound channels should be flagged invalid. The lsb is the rightmost digit\n");
+    printf("\n");
+    printf("  as10:\n");
+    printf("    --shim-name <name>      Shim name for AS10 (used for setting 'ShimName' metadata and setting video/sound parameters' checks)\n");
+    printf("                            list of known shims: %s\n", get_as10_shim_names().c_str());
+    printf("    --dm-file as10 <name>   Parse and set descriptive framework properties from text file <name>\n");
+    printf("                            N.B. 'ShimName' is the only mandatary property of AS10 metadata set\n");
+    printf("    --dm as10 <name> <value>    Set descriptive framework property\n");
+    printf("    --pass-dm               Copy descriptive metadata from the input file. The metadata can be overidden by other options\n");
+    printf("    --mpeg-checks [<name>]  Enable AS-10 compliancy checks. The file <name> is optional and contains expected descriptor values\n");
+    printf("    --loose-checks          Don't stop processing on detected compliancy violations\n");
+    printf("    --print-checks          Print default values of mpeg descriptors and report on descriptors either found in mpeg headers or copied from mxf headers\n");
+    printf("    --max-same-warnings <value>  Max same violations warnings logged, default 3\n");
+    printf("\n");
+    printf("  as11op1a/as11d10/op1a/d10/rdd9/as10:\n");
+    printf("    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
+    printf("    --fp-uid <umid>         Set the File Package UID. Autogenerated by default\n");
+    printf("\n");
+    printf("  avid:\n");
+    printf("    --project <name>        Set the Avid project name\n");
+    printf("    --tape <name>           Source tape name\n");
+    printf("    --import <name>         Source import name. <name> is one of the following:\n");
+    printf("                              - a file URL starting with 'file://'\n");
+    printf("                              - an absolute Windows (starts with '[A-Z]:') or *nix (starts with '/') filename\n");
+    printf("                              - a relative filename, which will be converted to an absolute filename\n");
+    printf("    --aux <hh:mm:sscff>     Set up to 5 auxiliary start timecodes. Multiple timecodes are separated by commas e.g. --aux 15:02:15:23,09:37:08:10\n");
+    printf("                            The c character in the pattern should be ':' for non-drop frame; any other character indicates drop frame\n");
+    printf("    --comment <string>      Add 'Comments' user comment to the MaterialPackage\n");
+    printf("    --desc <string>         Add 'Descript' user comment to the MaterialPackage\n");
+    printf("    --tag <name> <value>    Add <name> user comment to the MaterialPackage. Option can be used multiple times\n");
+    printf("    --locator <position> <comment> <color>\n");
+    printf("                            Add locator at <position> (in frame rate units) with <comment> and <color>\n");
+    printf("                            <position> format is o?hh:mm:sscff, where the optional 'o' indicates it is an offset\n");
+    printf("    --umid-type <type>      Set the UMID type that is generated for the Package UID properties.\n");
+    printf("                            The default <type> is 'aafsdk'.\n");
+    printf("                            The <type> is one of the following:\n");
+    printf("                              uuid       : UUID generation method\n");
+    printf("                              aafsdk     : same method as implemented in the AAF SDK\n");
+    printf("                                           This type is required to be compatible with some older Avid product versions\n");
+    printf("                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
+    printf("                              old-aafsdk : same method as implemented in revision 1.47 of AAF/ref-impl/src/impl/AAFUtils.c in the AAF SDK\n");
+    printf("                                           Note: this is not guaranteed to create a unique UMID when used in multiple processes\n");
+    printf("    --mp-uid <umid>         Set the Material Package UID. Autogenerated by default\n");
+    printf("    --mp-created <tstamp>   Set the Material Package creation date. Default is 'now'\n");
+    printf("    --psp-uid <umid>        Set the tape/import Source Package UID. Autogenerated by default\n");
+    printf("    --psp-created <tstamp>  Set the tape/import Source Package creation date. Default is 'now'\n");
+    printf("    --allow-no-avci-head    Allow inputs with no AVCI header (512 bytes, sequence and picture parameter sets)\n");
+    printf("    --avid-gf               Use the Avid growing file flavour\n");
+    printf("    --avid-gf-dur <dur>     Set the duration which should be shown whilst the file is growing\n");
+    printf("                            Avid will show 'Capture in Progress' when this option is used\n");
+    printf("\n");
+    printf("  op1a/avid:\n");
+    printf("    --force-no-avci-head    Strip AVCI header (512 bytes, sequence and picture parameter sets) if present\n");
+    printf("\n");
+    printf("  wave:\n");
+    printf("    --orig <name>           Set originator in the output Wave bext chunk. Default '%s'\n", DEFAULT_BEXT_ORIGINATOR);
+    printf("\n");
+    printf("  as02/op1a/as11op1a:\n");
+    printf("    --use-avc-subdesc       Use the AVC sub-descriptor rather than the MPEG video descriptor for AVC-Intra tracks\n");
+    printf("\n");
+    printf("  op1a/as11op1a/rdd9:\n");
+    printf("    --audio-layout <label>  Set the Wave essence descriptor channel assignment label which identifies the audio layout mode in operation\n");
+    printf("                            The <label> is one of the following:\n");
+    printf("                                * a SMPTE UL, formatted as a 'urn:smpte:ul:...',\n");
+    printf("                                * 'as11-mode-0', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02010000,\n");
+    printf("                                * 'as11-mode-1', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02020000,\n");
+    printf("                                * 'as11-mode-2', which corresponds to urn:smpte:ul:060e2b34.04010101.0d010801.02030000\n");
+    printf("                                * 'imf', which corresponds to urn:smpte:ul:060e2b34.0401010d.04020210.04010000\n");
+    printf("    --track-mca-labels <scheme> <file>  Insert audio labels defined in <file>. The 'as11' <scheme> will add an override and otherwise <scheme> is ignored\n");
+    printf("                                        The format of <file> is described in bmx/docs/mca_labels_format.md\n");
+    printf("                                        All tag symbols registered in the bmx code are available for use\n");
+    printf("                                        The 'as11' <scheme> will change the label associated with the 'chVIN' tag symbol to use the 'Visually Impaired Narrative' tag name, i.e. without a '-'\n");
+    printf("\n");
+    printf("\n");
+    printf("Input Options (must precede the input to which it applies):\n");
+    printf("  -a <n:d>                Image aspect ratio. Default parsed from essence or 16:9\n");
+    printf("  --bsar                  Set image aspect ratio in video bitstream. Currently supports D-10 essence types only\n");
+    printf("  --afd <value>           Active Format Descriptor 4-bit code from table 1 in SMPTE ST 2016-1. Default not set\n");
+    printf("  -c <depth>              Component depth for uncompressed/DV100/RDD-36 video. Either 8 or 10. Default parsed, 8 for uncompressed/DV100 and 10 for RDD-36\n");
+    printf("  --height <value>        Height of input uncompressed video data. Default is the production aperture height, except for PAL (592) and NTSC (496)\n");
+    printf("  --signal-std  <value>   Set the video signal standard. The <value> is one of the following:\n");
+    printf("                              'none', 'bt601', 'bt1358', 'st347', 'st274', 'st296', 'st349', 'st428'\n");
+    printf("  --frame-layout <value>  Set the video frame layout. The <value> is one of the following:\n");
+    printf("                              'fullframe', 'separatefield', 'singlefield', 'mixedfield', 'segmentedframe'\n");
+    printf("  --field-dom <value>     Set which field is first in temporal order. The <value> is 1 or 2\n");
+    printf("  --transfer-ch <value>   Set the transfer characteristic label\n");
+    printf("                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
+    printf("                              'bt470', 'bt709', 'st240', 'st274', 'bt1361', 'linear', 'dcdm',\n");
+    printf("                              'iec61966', 'bt2020', 'st2084', 'hlg'\n");
+    printf("  --coding-eq <value>     Set the coding equations label\n");
+    printf("                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
+    printf("                              'bt601', 'bt709', 'st240', 'ycgco', 'gbr', 'bt2020'\n");
+    printf("  --color-prim <value>    Set the color primaries label\n");
+    printf("                          The <value> is a SMPTE UL, formatted as a 'urn:smpte:ul:...' or one of the following:\n");
+    printf("                              'st170', 'bt470', 'bt709', 'bt2020', 'dcdm', 'p3'\n");
+    printf("  --color-siting <value>  Set the color siting. The <value> is one of the following:\n");
+    printf("                              'cositing', 'horizmp', '3tap', 'quincunx', 'bt601', 'linealt', 'vertmp', 'unknown'\n");
+    printf("                              (Note that 'bt601' is deprecated in SMPTE ST 377-1. Use 'cositing' instead)\n");
+    printf("  --black-level <value>   Set the CDCI black reference level\n");
+    printf("  --white-level <value>   Set the CDCI white reference level\n");
+    printf("  --color-range <value>   Set the CDCI color range\n");
+    printf("  --comp-max-ref <value>  Set the RGBA component maximum reference level\n");
+    printf("  --comp-min-ref <value>  Set the RGBA component minimum reference level\n");
+    printf("  --scan-dir <value>      Set the RGBA scanning direction\n");
+    printf("  --display-primaries <value>    Set the mastering display primaries.\n");
+    printf("                                 The <value> is an array of 6 unsigned integers separated by a ','.\n");
+    printf("  --display-white-point <value>  Set the mastering display white point chromaticity.\n");
+    printf("                                 The <value> is an array of 2 unsigned integers separated by a ','.\n");
+    printf("  --display-max-luma <value>     Set the mastering display maximum luminance.\n");
+    printf("  --display-min-luma <value>     Set the mastering display minimum luminance.\n");
+    printf("  --rdd36-opaque          Treat RDD-36 4444 or 4444 XQ as opaque by omitting the Alpha Sample Depth property\n");
+    printf("  --active-width          Set the Active Width of the active area rectangle\n");
+    printf("  --active-height         Set the Active Height of the active area rectangle\n");
+    printf("  --active-x-offset       Set the Active X Offset of the active area rectangle\n");
+    printf("  --active-y-offset       Set the Active Y Offset of the active area rectangle\n");
+    printf("  --display-f2-offset     Set the default Display F2 Offset if none is extracted from the essence\n");
+    printf("  --center-cut-4-3        Add the Alternative Center Cut 4:3\n");
+    printf("  --center-cut-14-9       Add the Alternative Center Cut 14:9\n");
+    printf("  -s <bps>                Audio sampling rate numerator for raw pcm. Default %d\n", DEFAULT_SAMPLING_RATE.numerator);
+    printf("  -q <bps>                Audio quantization bits per sample for raw pcm. Either 16 or 24. Default 16\n");
+    printf("  --audio-chan <count>    Audio channel count for raw pcm. Default 1\n");
+    printf("  --locked <bool>         Indicate whether the number of audio samples is locked to the video. Either true or false. Default not set\n");
+    printf("  --audio-ref <level>     Audio reference level, number of dBm for 0VU. Default not set\n");
+    printf("  --dial-norm <value>     Gain to be applied to normalize perceived loudness of the clip. Default not set\n");
+    printf("  --ref-image-edit-rate <rate>     Override or set the Reference Image Edit Rate\n");
+    printf("                                   The <rate> is either 'num', 'num'/'den', 23976 (=24000/1001), 2997 (=30000/1001) or 5994 (=60000/1001)\n");
+    printf("  --ref-audio-align-level <value>  Override or set the Reference Audio Alignment Level\n");
+    printf("  --anc-const <size>      Set the constant ANC data frame <size>\n");
+    printf("  --vbi-const <size>      Set the constant VBI data frame <size>\n");
+    printf("  --off <bytes>           Skip <bytes> at the start of the next input/track's file\n");
+    printf("  --maxlen <bytes>        Maximum number of essence data bytes to read from next input/track's file\n");
+    printf("  --klv <key>             Essence data is read from the KLV data in the next input/track's file\n");
+    printf("                          <key> should have one of the following values:\n");
+    printf("                            - 's', which means the first 16 bytes, at file position 0 or --off byte offset, are taken to be the Key\n");
+    printf("                            - optional '0x' followed by 8 hexadecimal characters which represents the 4-byte track number part of a generic container essence Key\n");
+    printf("                            - 32 hexadecimal characters representing a 16-byte Key\n");
+    printf("  --fill-pattern-gaps     Fill gaps in a numbered sequence pattern of raw files by repeating the contents of the file at the start of a gap\n");
+    printf("  --track-num <num>       Set the output track number. Default track number equals last track number of same picture/sound type + 1\n");
+    printf("                          For as11d10/d10 the track number must be > 0 and <= 8 because the AES-3 channel index equals track number - 1\n");
+    printf("  --avci-guess <i/p>      Guess interlaced ('i') or progressive ('p') AVC-Intra when using the --avci option with 1080p25/i50 or 1080p30/i60\n");
+    printf("                          The default guess uses the H.264 frame_mbs_only_flag field\n");
+    printf("  --fixed-size            Set to indicate that the d10 frames have a fixed size and therefore do not need to be parsed after the first frame\n");
+    printf("  --vc2-mode <mode>       Set the mode that determines how the VC-2 data is wrapped\n");
+    printf("                          <mode> is one of the following integer values:\n");
+    printf("                            0: Passthrough input, but add a sequence header if not present, remove duplicate/redundant sequence headers\n");
+    printf("                               and fix any incorrect parse info offsets and picture numbers\n");
+    printf("                            1: (default) Same as 0, but remove auxiliary and padding data units and complete the sequence in each frame\n");
+    printf("\n");
+    printf("  as02:\n");
+    printf("    --trk-out-start <offset>   Offset to start of first output frame, eg. pre-charge in MPEG-2 Long GOP\n");
+    printf("    --trk-out-end <offset>     Offset (positive value) from last frame to last output frame, eg. rollout in MPEG-2 Long GOP\n");
+    printf("\n");
+    printf("\n");
+    printf("Inputs:\n");
+    printf("  --dv <name>             Raw DV video input file\n");
+    printf("  --iecdv25 <name>        Raw IEC DV25 video input file\n");
+    printf("  --dvbased25 <name>      Raw DV-Based DV25 video input file\n");
+    printf("  --dv50 <name>           Raw DV50 video input file\n");
+    printf("  --dv100_1080i <name>    Raw DV100 1080i video input file\n");
+    printf("  --dv100_1080p <name>    Raw DV100 1080p video input file\n");
+    printf("  --dv100_720p <name>     Raw DV100 720p video input file\n");
+    printf("  --d10 <name>            Raw D10 video input file\n");
+    printf("  --d10_30 <name>         Raw D10 30Mbps video input file\n");
+    printf("  --d10_40 <name>         Raw D10 40Mbps video input file\n");
+    printf("  --d10_50 <name>         Raw D10 50Mbps video input file\n");
+    printf("  --avci <name>           Raw AVC-Intra video input file. See also --avci-guess option\n");
+    printf("  --avci200_1080i <name>  Raw AVC-Intra 200 1080i video input file\n");
+    printf("  --avci200_1080p <name>  Raw AVC-Intra 200 1080p video input file\n");
+    printf("  --avci200_720p <name>   Raw AVC-Intra 200 720p video input file\n");
+    printf("  --avci100_1080i <name>  Raw AVC-Intra 100 1080i video input file\n");
+    printf("  --avci100_1080p <name>  Raw AVC-Intra 100 1080p video input file\n");
+    printf("  --avci100_720p <name>   Raw AVC-Intra 100 720p video input file\n");
+    printf("  --avci50_1080i <name>   Raw AVC-Intra 50 1080i video input file\n");
+    printf("  --avci50_1080p <name>   Raw AVC-Intra 50 1080p video input file\n");
+    printf("  --avci50_720p <name>    Raw AVC-Intra 50 720p video input file\n");
+    printf("  --avc <name>                 Raw AVC video input file\n");
+    printf("  --avc_baseline <name>        Raw AVC Baseline profile video input file\n");
+    printf("  --avc_constr_baseline <name> Raw AVC Constrained Baseline profile video input file\n");
+    printf("  --avc_main <name>            Raw AVC Main profile video input file\n");
+    printf("  --avc_extended <name>        Raw AVC Extended profile video input file\n");
+    printf("  --avc_high <name>            Raw AVC High profile video input file\n");
+    printf("  --avc_high_10 <name>         Raw AVC High 10 profile video input file\n");
+    printf("  --avc_high_422 <name>        Raw AVC High 422 profile video input file\n");
+    printf("  --avc_high_444 <name>        Raw AVC High 444 profile video input file\n");
+    printf("  --avc_high_10_intra <name>   Raw AVC High 10 Intra profile video input file\n");
+    printf("  --avc_high_422_intra <name>  Raw AVC High 422 Intra profile video input file\n");
+    printf("  --avc_high_444_intra <name>  Raw AVC High 444 Intra profile video input file\n");
+    printf("  --avc_cavlc_444 <name>       Raw AVC CAVLC 444 profile video input file\n");
+    printf("  --unc <name>            Raw uncompressed SD UYVY 422 video input file\n");
+    printf("  --unc_1080i <name>      Raw uncompressed HD 1080i UYVY 422 video input file\n");
+    printf("  --unc_1080p <name>      Raw uncompressed HD 1080p UYVY 422 video input file\n");
+    printf("  --unc_720p <name>       Raw uncompressed HD 720p UYVY 422 video input file\n");
+    printf("  --unc_3840 <name>       Raw uncompressed UHD 3840x2160 UYVY 422 video input file\n");
+    printf("  --avid_alpha <name>               Raw Avid alpha component SD video input file\n");
+    printf("  --avid_alpha_1080i <name>         Raw Avid alpha component HD 1080i video input file\n");
+    printf("  --avid_alpha_1080p <name>         Raw Avid alpha component HD 1080p video input file\n");
+    printf("  --avid_alpha_720p <name>          Raw Avid alpha component HD 720p video input file\n");
+    printf("  --mpeg2lg <name>                  Raw MPEG-2 Long GOP video input file\n");
+    printf("  --mpeg2lg_422p_ml_576i <name>     Raw MPEG-2 Long GOP 422P@ML 576i video input file\n");
+    printf("  --mpeg2lg_mp_ml_576i <name>       Raw MPEG-2 Long GOP MP@ML 576i video input file\n");
+    printf("  --mpeg2lg_422p_hl_1080i <name>    Raw MPEG-2 Long GOP 422P@HL 1080i video input file\n");
+    printf("  --mpeg2lg_422p_hl_1080p <name>    Raw MPEG-2 Long GOP 422P@HL 1080p video input file\n");
+    printf("  --mpeg2lg_422p_hl_720p <name>     Raw MPEG-2 Long GOP 422P@HL 720p video input file\n");
+    printf("  --mpeg2lg_mp_hl_1920_1080i <name> Raw MPEG-2 Long GOP MP@HL 1920x1080i video input file\n");
+    printf("  --mpeg2lg_mp_hl_1920_1080p <name> Raw MPEG-2 Long GOP MP@HL 1920x1080p video input file\n");
+    printf("  --mpeg2lg_mp_hl_1440_1080i <name> Raw MPEG-2 Long GOP MP@HL 1440x1080i video input file\n");
+    printf("  --mpeg2lg_mp_hl_1440_1080p <name> Raw MPEG-2 Long GOP MP@HL 1440x1080p video input file\n");
+    printf("  --mpeg2lg_mp_hl_720p <name>       Raw MPEG-2 Long GOP MP@HL 720p video input file\n");
+    printf("  --mpeg2lg_mp_h14_1080i <name>     Raw MPEG-2 Long GOP MP@H14 1080i video input file\n");
+    printf("  --mpeg2lg_mp_h14_1080p <name>     Raw MPEG-2 Long GOP MP@H14 1080p video input file\n");
+    printf("  --mjpeg21 <name>        Raw Avid MJPEG 2:1 video input file\n");
+    printf("  --mjpeg31 <name>        Raw Avid MJPEG 3:1 video input file\n");
+    printf("  --mjpeg101 <name>       Raw Avid MJPEG 10:1 video input file\n");
+    printf("  --mjpeg201 <name>       Raw Avid MJPEG 20:1 video input file\n");
+    printf("  --mjpeg41m <name>       Raw Avid MJPEG 4:1m video input file\n");
+    printf("  --mjpeg101m <name>      Raw Avid MJPEG 10:1m video input file\n");
+    printf("  --mjpeg151s <name>      Raw Avid MJPEG 15:1s video input file\n");
+    printf("  --rdd36_422_proxy <name>   Raw SMPTE RDD-36 (ProRes) 4:2:2 Proxy profile input file\n");
+    printf("  --rdd36_422_lt <name>      Raw SMPTE RDD-36 (ProRes) 4:2:2 LT profile input file\n");
+    printf("  --rdd36_422 <name>         Raw SMPTE RDD-36 (ProRes) 4:2:2 profile input file\n");
+    printf("  --rdd36_422_hq <name>      Raw SMPTE RDD-36 (ProRes) 4:2:2 HQ profile input file\n");
+    printf("  --rdd36_4444 <name>        Raw SMPTE RDD-36 (ProRes) 4:4:4:4 profile input file\n");
+    printf("  --rdd36_4444_xq <name>     Raw SMPTE RDD-36 (ProRes) 4:4:4:4 XQ profile input file\n");
+    printf("  --j2c_cdci <name|j2cpattern>  Raw JPEG 2000 (ISO/IEC 15444-1) codestream representing components (e.g. YCbCr) described by a MXF CDCI descriptor\n");
+    printf("                                If a '%%' is in the value then it is assumed to be a <j2cpattern> for a sequence of files, each containing a single frame\n");
+    printf("                                See Notes below for a detailed description of <j2cpattern>\n");
+    printf("  --j2c_rgba <name|j2cpattern>  Raw JPEG 2000 (ISO/IEC 15444-1) codestream representing components (e.g. RGB) described by a MXF RGBA descriptor\n");
+    printf("                                If a '%%' is in the value then it is assumed to be a <j2cpattern> for a sequence of files, each containing a single frame\n");
+    printf("                                See Notes below for a detailed description of <j2cpattern>\n");
+    printf("  --vc2 <name>            Raw VC2 input file\n");
+    printf("  --vc3 <name>            Raw VC3/DNxHD input file\n");
+    printf("  --vc3_1080p_1235 <name> Raw VC3/DNxHD 1920x1080p 220/185/175 Mbps 10bit input file\n");
+    printf("  --vc3_1080p_1237 <name> Raw VC3/DNxHD 1920x1080p 145/120/115 Mbps input file\n");
+    printf("  --vc3_1080p_1238 <name> Raw VC3/DNxHD 1920x1080p 220/185/175 Mbps input file\n");
+    printf("  --vc3_1080i_1241 <name> Raw VC3/DNxHD 1920x1080i 220/185 Mbps 10bit input file\n");
+    printf("  --vc3_1080i_1242 <name> Raw VC3/DNxHD 1920x1080i 145/120 Mbps input file\n");
+    printf("  --vc3_1080i_1243 <name> Raw VC3/DNxHD 1920x1080i 220/185 Mbps input file\n");
+    printf("  --vc3_1080i_1244 <name> Raw VC3/DNxHD 1920x1080i 145/120 Mbps input file\n");
+    printf("  --vc3_720p_1250 <name>  Raw VC3/DNxHD 1280x720p 220/185/110/90 Mbps 10bit input file\n");
+    printf("  --vc3_720p_1251 <name>  Raw VC3/DNxHD 1280x720p 220/185/110/90 Mbps input file\n");
+    printf("  --vc3_720p_1252 <name>  Raw VC3/DNxHD 1280x720p 220/185/110/90 Mbps input file\n");
+    printf("  --vc3_1080p_1253 <name> Raw VC3/DNxHD 1920x1080p 45/36 Mbps input file\n");
+    printf("  --vc3_720p_1258 <name>  Raw VC3/DNxHD 1280x720p 45 Mbps input file\n");
+    printf("  --vc3_1080p_1259 <name> Raw VC3/DNxHD 1920x1080p 85 Mbps input file\n");
+    printf("  --vc3_1080i_1260 <name> Raw VC3/DNxHD 1920x1080i 85 Mbps input file\n");
+    printf("  --pcm <name>            Raw PCM audio input file\n");
+    printf("  --wave <name>           Wave PCM audio input file\n");
+    printf("  --anc <name>            Raw ST 436 Ancillary data. Currently requires the --anc-const option\n");
+    printf("  --vbi <name>            Raw ST 436 Vertical Blanking Interval data. Currently requires the --vbi-const option\n");
+    printf("  --tt <manifest>         Manifest file containing Timed Text metadata\n");
+    printf("\n\n");
+    printf("Notes:\n");
+    printf(" - filename pattern: Clip types producing a single output file may use a filename pattern with variables that get substituted\n");
+    printf("                     Pattern variables start with a '{' and end with a '}'. E.g. 'output_{type}_{fp_uuid}.mxf'\n");
+    printf("                     The following variables are available:\n");
+    printf("                       - {type}: Is replaced with the name for video, audio, data or mixed essence types\n");
+    printf("                                 See the --ess-type-names option for the default names and use the option to change them\n");
+    printf("                       - {mp_uuid}: The UUID material number in a material package UMID\n");
+    printf("                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
+    printf("                       - {mp_umid}: The material package UMID\n");
+    printf("                       - {fp_uuid}: The UUID material number in a file source package UMID\n");
+    printf("                                    The clip writers will by default generate UMIDs with UUID material numbers\n");
+    printf("                       - {fp_umid}: The file source package UMID\n");
+    printf(" - <umid> format is 64 hexadecimal characters and any '.' and '-' characters are ignored\n");
+    printf(" - <uuid> format is 32 hexadecimal characters and any '.' and '-' characters are ignored\n");
+    printf(" - <tstamp> format is YYYY-MM-DDThh:mm:ss:qm where qm is in units of 1/250th second\n");
+    printf(" - <j2cpattern>: Each file name must include an integer frame number in the sequence.\n");
+    printf("                 <j2cpattern> is a file path that must contain a single '%%d' where the frame number appears in the name.\n");
+    printf("                 <j2cpattern> must not contain any other '%%' characters.\n");
+    printf("                 If --fill-pattern-gaps option is used then gaps in frame numbers are filled by repeating the previous frame.\n");
+    printf("                 Example: 'inputs/frame_%%d.j2c' for input files `inputs/frame_00001.j2c' etc..\n");
+    printf("\n");
+    printf(" The track mapping <expr> format is one of the following:\n");
+    printf("     'mono'     : each input audio channel is mapped to a single-channel output track\n");
+    printf("     'stereo'   : input audio channels are paired to stereo-channel output tracks\n");
+    printf("                  A silence channel is added to the last output track if the channel count is odd\n");
+    printf("     'singlemca': all input audio channels are mapped to a single multi-channel output track\n");
+    printf("     <pattern>  : a pattern defining how input channels map to output track channels - see below\n");
+    printf("\n");
+    printf(" The track mapping <pattern> specifies how input audio channels are mapped to output track channels\n");
+    printf(" A <pattern> consists of a list of <group>s separated by a ';'.\n");
+    printf(" A <group> starts with an optional 'm', followed by a list of <element> separated by a ','.\n");
+    printf("   An 'm' indicates that each channel in the <group> is mapped to separate single-channel output track.\n");
+    printf("   If an 'm' is not present then the channels are mapped to a single output track.\n");
+    printf(" A <element> is either a <channel>, <range>, <silence> or <remainder>.\n");
+    printf(" A <channel> is an input channel number starting from 0.\n");
+    printf("   The input channel number is the number derived from the input track order reported by mxf2raw for the\n");
+    printf("   input files in the same order and including any --disable input options. Each channel in a track\n");
+    printf("   contributes 1 to the overall channel number.\n");
+    printf(" A <range> is 2 <channel>s separated by a '-' and includes all channels starting with the first number\n");
+    printf("   and ending with the last number.\n");
+    printf(" A <silence> is 's' followed by a <count> and results in <count> silence channels added to the output track.\n");
+    printf(" A <remainder> is 'x', and results in all remaining channels being added to the output track.\n");
+    printf("\n");
+    printf("Here are some <pattern> examples:\n");
+    printf("    'mx'     : equivalent to 'mono'\n");
+    printf("    '0,1;x'  : the first 2 channels mapped to a stereo output track and all remaining channels mapped\n");
+    printf("               to a single multi-channel track\n");
+    printf("    '2-7;0,1': 6 channel output track followed by a 2 channel output track\n");
+    printf("    '0,1,s2' : 2 input channels plus 2 silence channels mapped to a single output track\n");
 }
 
 int main(int argc, const char** argv)
@@ -982,7 +989,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -993,13 +1000,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_log_level(argv[cmdln_index + 1], &log_level))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1009,13 +1016,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_clip_type(argv[cmdln_index + 1], &clip_type, &clip_sub_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1025,7 +1032,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1036,13 +1043,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_essence_type_names(argv[cmdln_index + 1], &filename_essence_type_names))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1052,14 +1059,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 5 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing arguments for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_product_info(&argv[cmdln_index + 1], 5, &company_name, &product_name, &product_version,
                                     &version_string, &product_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid values '%s' etc. for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1070,13 +1077,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_timestamp(argv[cmdln_index + 1], &creation_date))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1087,13 +1094,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_rate(argv[cmdln_index + 1], &frame_rate))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1104,13 +1111,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_rate(argv[cmdln_index + 1], &default_frame_rate))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1120,7 +1127,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1131,7 +1138,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1142,13 +1149,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &duration) != 1 || duration < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1158,13 +1165,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%f", &rt_factor) != 1 || rt_factor <= 0.0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1175,14 +1182,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_avci_header(argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3],
                                    &avci_header_inputs))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid values '%s', '%s', '%s' for Option '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3], argv[cmdln_index]);
                 return 1;
@@ -1197,13 +1204,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_mic_type(argv[cmdln_index + 1], &mic_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1237,14 +1244,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &max_mpeg_check_same_warn_messages) != 1 ||
                 max_mpeg_check_same_warn_messages < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1254,7 +1261,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1268,7 +1275,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1279,7 +1286,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1290,7 +1297,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1301,14 +1308,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (as10_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as10_helper.SetFrameworkProperty(argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to set '%s' framework property '%s' to '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]);
                 return 1;
@@ -1316,7 +1323,7 @@ int main(int argc, const char** argv)
             if (as11_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as11_helper.SetFrameworkProperty(argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to set '%s' framework property '%s' to '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2], argv[cmdln_index + 3]);
                 return 1;
@@ -1327,14 +1334,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 2 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (as10_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as10_helper.ParseFrameworkFile(argv[cmdln_index + 1], argv[cmdln_index + 2]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to parse '%s' framework file '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2]);
                 return 1;
@@ -1342,7 +1349,7 @@ int main(int argc, const char** argv)
             if (as11_helper.SupportFrameworkType(argv[cmdln_index + 1]) &&
                 !as11_helper.ParseFrameworkFile(argv[cmdln_index + 1], argv[cmdln_index + 2]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to parse '%s' framework file '%s'\n",
                         argv[cmdln_index + 1], argv[cmdln_index + 2]);
                 return 1;
@@ -1353,7 +1360,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1364,13 +1371,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!as11_helper.ParseSpecificationId(argv[cmdln_index + 1]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1380,14 +1387,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &output_start_offset) != 1 ||
                 output_start_offset < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1397,14 +1404,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &output_end_offset) != 1 ||
                 output_end_offset < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1414,14 +1421,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value < 0 || value > 255)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1477,14 +1484,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!AS11Helper::ParseXMLSchemeId(argv[cmdln_index + 1], &next_embed_xml.scheme_id) &&
                 !parse_mxf_auid(argv[cmdln_index + 1], &next_embed_xml.scheme_id))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1494,7 +1501,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1505,7 +1512,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1526,13 +1533,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_d10_sound_flags(argv[cmdln_index + 1], &d10_mute_sound_flags))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1542,13 +1549,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_d10_sound_flags(argv[cmdln_index + 1], &d10_invalid_sound_flags))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1558,7 +1565,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1569,7 +1576,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1580,7 +1587,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1591,7 +1598,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1607,7 +1614,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1618,7 +1625,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for %s\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1629,7 +1636,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 2 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for %s\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1640,7 +1647,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for %s\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1649,7 +1656,7 @@ int main(int argc, const char** argv)
             locator.locator.comment = argv[cmdln_index + 2];
             if (!parse_color(argv[cmdln_index + 3], &locator.locator.color))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Failed to read --locator <color> value '%s'\n", argv[cmdln_index + 3]);
                 return 1;
             }
@@ -1660,13 +1667,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_avid_umid_type(argv[cmdln_index + 1], &avid_umid_type))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1676,13 +1683,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_umid(argv[cmdln_index + 1], &mp_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1693,13 +1700,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_timestamp(argv[cmdln_index + 1], &mp_created))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1710,13 +1717,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_umid(argv[cmdln_index + 1], &fp_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1727,13 +1734,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_umid(argv[cmdln_index + 1], &psp_uid))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1744,13 +1751,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_timestamp(argv[cmdln_index + 1], &psp_created))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1769,13 +1776,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &avid_gf_duration) != 1 || avid_gf_duration < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1790,7 +1797,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1801,13 +1808,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!track_mapper.ParseMapDef(argv[cmdln_index + 1]))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1827,13 +1834,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_bytes_size(argv[cmdln_index + 1], &i64value) || i64value > UINT32_MAX)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1844,7 +1851,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 3 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument(s) for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -1859,14 +1866,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!AppMCALabelHelper::ParseAudioLayoutMode(argv[cmdln_index + 1], &audio_layout_mode_label) &&
                 !parse_mxf_auid(argv[cmdln_index + 1], &audio_layout_mode_label))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1881,13 +1888,13 @@ int main(int argc, const char** argv)
             BMX_REGRESSION_TEST = true;
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &regtest_end) != 1 || regtest_end < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1913,13 +1920,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d:%d", &num, &den) != 2 || num <= 0 || den <= 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1938,14 +1945,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value <= 0 || value > 255)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1957,14 +1964,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &value) != 1 ||
                 (value != 8 && value != 10))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1976,12 +1983,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &value) != 1 || value == 0) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1993,12 +2000,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_signal_standard(argv[cmdln_index + 1], &input.signal_standard)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2010,12 +2017,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_layout(argv[cmdln_index + 1], &input.frame_layout)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2027,12 +2034,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_field_dominance(argv[cmdln_index + 1], &input.field_dominance)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2044,12 +2051,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_transfer_ch(argv[cmdln_index + 1], &input.transfer_ch)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2061,12 +2068,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_coding_equations(argv[cmdln_index + 1], &input.coding_equations)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2078,12 +2085,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_color_primaries(argv[cmdln_index + 1], &input.color_primaries)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2095,12 +2102,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_color_siting(argv[cmdln_index + 1], &input.color_siting)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2112,12 +2119,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2129,12 +2136,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2146,12 +2153,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2163,12 +2170,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2180,12 +2187,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2197,12 +2204,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2214,12 +2221,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_three_color_primaries(argv[cmdln_index + 1], &three_color_primaries)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2231,12 +2238,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_color_primary(argv[cmdln_index + 1], &color_primary)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2248,12 +2255,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2265,12 +2272,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2287,12 +2294,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2304,12 +2311,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2321,12 +2328,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2338,12 +2345,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2355,12 +2362,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2382,13 +2389,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1 && uvalue > 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2401,14 +2408,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &value) != 1 ||
                 (value != 16 && value != 24))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2420,14 +2427,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &value) != 1 ||
                 value == 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2439,13 +2446,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_bool(argv[cmdln_index + 1], &input.locked))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2457,14 +2464,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value < -128 || value > 127)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2476,14 +2483,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1 ||
                 value < -128 || value > 127)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2495,13 +2502,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_frame_rate(argv[cmdln_index + 1], &rate))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2513,12 +2520,12 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &value) != 1) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2530,13 +2537,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2548,13 +2555,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2566,14 +2573,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &input.file_start_offset) != 1 ||
                 input.file_start_offset < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2584,14 +2591,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &input.ess_max_length) != 1 ||
                 input.ess_max_length <= 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2602,13 +2609,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_klv_opt(argv[cmdln_index + 1], &input.klv_key, &input.klv_track_num))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2625,13 +2632,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &uvalue) != 1)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2643,7 +2650,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2651,7 +2658,7 @@ int main(int argc, const char** argv)
                                   &input.avci_guess_interlaced,
                                   &input.avci_guess_progressive))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2667,13 +2674,13 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (!parse_vc2_mode(argv[cmdln_index + 1], &input.vc2_mode_flags))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2684,14 +2691,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &input.output_start_offset) != 1 ||
                 input.output_start_offset < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2702,14 +2709,14 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for Option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &input.output_end_offset) != 1 ||
                 input.output_end_offset < 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Invalid value '%s' for Option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2731,7 +2738,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2744,7 +2751,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2757,7 +2764,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2770,7 +2777,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2783,7 +2790,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2796,7 +2803,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2809,7 +2816,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2822,7 +2829,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2835,7 +2842,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2848,7 +2855,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2861,7 +2868,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2874,7 +2881,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2890,7 +2897,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2906,7 +2913,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2922,7 +2929,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2935,7 +2942,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2948,7 +2955,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2961,7 +2968,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2974,7 +2981,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -2987,7 +2994,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3000,7 +3007,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3013,7 +3020,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3026,7 +3033,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3039,7 +3046,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3052,7 +3059,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3065,7 +3072,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3078,7 +3085,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3091,7 +3098,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3104,7 +3111,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3117,7 +3124,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3130,7 +3137,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3143,7 +3150,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3156,7 +3163,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3169,7 +3176,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3182,7 +3189,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3195,7 +3202,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3208,7 +3215,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3221,7 +3228,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3234,7 +3241,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3247,7 +3254,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3260,7 +3267,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3273,7 +3280,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3286,7 +3293,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3299,7 +3306,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3312,7 +3319,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3325,7 +3332,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3338,7 +3345,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3351,7 +3358,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3364,7 +3371,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3377,7 +3384,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3390,7 +3397,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3403,7 +3410,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3416,7 +3423,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3429,7 +3436,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3442,7 +3449,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3455,7 +3462,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3468,7 +3475,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3481,7 +3488,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3494,7 +3501,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3507,7 +3514,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3520,7 +3527,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3533,7 +3540,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3546,7 +3553,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3559,7 +3566,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3572,7 +3579,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3585,7 +3592,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3601,7 +3608,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3617,7 +3624,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3630,7 +3637,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3643,7 +3650,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3656,7 +3663,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3669,7 +3676,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3682,7 +3689,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3695,7 +3702,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3708,7 +3715,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3721,7 +3728,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3734,7 +3741,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3747,7 +3754,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3760,7 +3767,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3773,7 +3780,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3786,7 +3793,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3799,7 +3806,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3812,7 +3819,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3825,7 +3832,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3838,7 +3845,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3852,19 +3859,19 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (have_anc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Multiple '%s' inputs are not permitted\n", argv[cmdln_index]);
                 return 1;
             }
             if (input.anc_const_size == 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing or zero '--anc-const' option for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3878,19 +3885,19 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (have_vbi)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Multiple '%s' inputs are not permitted\n", argv[cmdln_index]);
                 return 1;
             }
             if (input.vbi_const_size == 0)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing or zero '--vbi-const' option for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3904,7 +3911,7 @@ int main(int argc, const char** argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 fprintf(stderr, "Missing argument for input '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -3925,26 +3932,26 @@ int main(int argc, const char** argv)
     clear_input(&input);
 
     if (cmdln_index != argc) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "Unknown Input Option '%s'\n", argv[cmdln_index]);
         return 1;
     }
 
     if (!output_name) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "No output name given\n");
         return 1;
     }
 
     if (inputs.empty()) {
-        usage(argv[0]);
+        usage_ref(argv[0]);
         fprintf(stderr, "No raw inputs given\n");
         return 1;
     }
 
     if (clip_type == CW_AS02_CLIP_TYPE || clip_type == CW_AVID_CLIP_TYPE) {
         if (uses_filename_pattern_variables(output_name)) {
-            usage(argv[0]);
+            usage_ref(argv[0]);
             fprintf(stderr, "Clip type '%s' does not support output filename pattern variables\n",
                     clip_type_to_string(clip_type, clip_sub_type));
             return 1;
@@ -3957,7 +3964,7 @@ int main(int argc, const char** argv)
     if (clip_sub_type == AS10_CLIP_SUB_TYPE) {
         const char *as10_shim_name = as10_helper.GetShimName();
         if (!as10_shim_name) {
-            usage(argv[0]);
+            usage_ref(argv[0]);
             fprintf(stderr, "Set required 'ShimName' property for as10 output");
             return 1;
         }
@@ -4547,7 +4554,7 @@ int main(int argc, const char** argv)
 
         start_timecode.Init(frame_rate, false);
         if (start_timecode_str && !parse_timecode(start_timecode_str, frame_rate, &start_timecode)) {
-            usage(argv[0]);
+            usage_ref(argv[0]);
             log_error("Invalid value '%s' for Option '-t'\n", start_timecode_str);
             throw false;
         }
@@ -4561,7 +4568,7 @@ int main(int argc, const char** argv)
         {
             Timecode auxiliary_timecode;
             if (!parse_timecode(auxiliary_timecode_strings[i].c_str(), frame_rate, &auxiliary_timecode)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 log_error("Invalid value '%s' for Option '--aux'\n", auxiliary_timecode_strings[i].c_str());
                 throw false;
             }
@@ -4571,7 +4578,7 @@ int main(int argc, const char** argv)
         if (partition_interval_str) {
             if (!parse_partition_interval(partition_interval_str, frame_rate, &partition_interval))
             {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 log_error("Invalid value '%s' for Option '--part'\n", partition_interval_str);
                 throw false;
             }
@@ -4587,7 +4594,7 @@ int main(int argc, const char** argv)
 
         for (i = 0; i < locators.size(); i++) {
             if (!parse_position(locators[i].position_str, start_timecode, frame_rate, &locators[i].locator.position)) {
-                usage(argv[0]);
+                usage_ref(argv[0]);
                 log_error("Invalid value '%s' for Option '--locator'\n", locators[i].position_str);
                 throw false;
             }

--- a/tools/h264dump.c
+++ b/tools/h264dump.c
@@ -2564,16 +2564,20 @@ static int parse_nal_unit(ParseContext *context)
 
 
 
-static void print_usage(const char *cmd)
+static void print_usage(const char *cmd, int error)
 {
-    fprintf(stderr, "Text dump raw H.264 bitstream files\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s [options] <filename>\n", cmd);
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -h | --help      Show help and exit\n");
-    fprintf(stderr, "  --isom <llen>    NAL units are prefixed by a <llen> big-endian size word\n");
-    fprintf(stderr, "                   NOTE: NAL units will not be parsed correctly if there is no SPS or PPS\n");
-    fprintf(stderr, "                   An Annex B byte stream format is assumed by default\n");
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "Text dump raw H.264 bitstream files\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s [options] <filename>\n", cmd);
+    fprintf(output, "Options:\n");
+    fprintf(output, "  -h | --help      Show help and exit\n");
+    fprintf(output, "  --isom <llen>    NAL units are prefixed by a <llen> big-endian size word\n");
+    fprintf(output, "                   NOTE: NAL units will not be parsed correctly if there is no SPS or PPS\n");
+    fprintf(output, "                   An Annex B byte stream format is assumed by default\n");
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -2584,7 +2588,7 @@ int main(int argc, const char **argv)
     int cmdln_index;
 
     if (argc <= 1) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 0);
         return 0;
     }
 
@@ -2592,20 +2596,20 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "-h") == 0 ||
             strcmp(argv[cmdln_index], "--help") == 0)
         {
-            print_usage(argv[0]);
+            print_usage(argv[0], 0);
             return 0;
         }
         else if (strcmp(argv[cmdln_index], "--isom") == 0)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%u", &isom_llen) != 1 || isom_llen == 0 || isom_llen > 4)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -2618,12 +2622,12 @@ int main(int argc, const char **argv)
     }
 
     if (cmdln_index + 1 < argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Unknown option '%s'\n", argv[cmdln_index]);
         return 1;
     }
     if (cmdln_index >= argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Missing <filename>\n");
         return 1;
     }

--- a/tools/j2cdump.c
+++ b/tools/j2cdump.c
@@ -947,14 +947,18 @@ static int parse_marker_segment(ParseContext *context, uint16_t marker, uint16_t
 }
 
 
-static void print_usage(const char *cmd)
+static void print_usage(const char *cmd, int error)
 {
-    fprintf(stderr, "Text dump of J2C codestreams (ISO/IEC 15444-1)\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s [options] <filename>\n", cmd);
-    fprintf(stderr, "  Indicate standard input using '-' for <filename>\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -h | --help      Show help and exit\n");
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "Text dump of J2C codestreams (ISO/IEC 15444-1)\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s [options] <filename>\n", cmd);
+    fprintf(output, "  Indicate standard input using '-' for <filename>\n");
+    fprintf(output, "Options:\n");
+    fprintf(output, "  -h | --help      Show help and exit\n");
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -967,7 +971,7 @@ int main(int argc, const char **argv)
     uint16_t tile_part_index = 0;
 
     if (argc <= 1) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 0);
         return 0;
     }
 
@@ -975,7 +979,7 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "-h") == 0 ||
             strcmp(argv[cmdln_index], "--help") == 0)
         {
-            print_usage(argv[0]);
+            print_usage(argv[0], 0);
             return 0;
         }
         else
@@ -985,12 +989,12 @@ int main(int argc, const char **argv)
     }
 
     if (cmdln_index + 1 < argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Unknown option '%s'\n", argv[cmdln_index]);
         return 1;
     }
     if (cmdln_index >= argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Missing <filename>\n");
         return 1;
     }

--- a/tools/jp2extract.c
+++ b/tools/jp2extract.c
@@ -340,17 +340,21 @@ static int extract_box(ParseContext *context, int with_header)
     return 1;
 }
 
-static void print_usage(const char *cmd)
+static void print_usage(const char *cmd, int error)
 {
-    fprintf(stderr, "Extract J2C codestreams from 'jp2c' boxes from a JP2 file (ISO/IEC 15444-1 Annex I)\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s [options] <input filename> <output filename>\n", cmd);
-    fprintf(stderr, "  Indicate standard input or output using '-'\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -h | --help      Show help and exit\n");
-    fprintf(stderr, "  --with-header    Include the input file's 'jp2c' box header in the output\n");
-    fprintf(stderr, "  --start <n>      Start extracting from the <n>th 'jp2c' box\n");
-    fprintf(stderr, "  --count <n>      Extract at most <n> 'jp2c' boxes\n");
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "Extract J2C codestreams from 'jp2c' boxes from a JP2 file (ISO/IEC 15444-1 Annex I)\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s [options] <input filename> <output filename>\n", cmd);
+    fprintf(output, "  Indicate standard input or output using '-'\n");
+    fprintf(output, "Options:\n");
+    fprintf(output, "  -h | --help      Show help and exit\n");
+    fprintf(output, "  --with-header    Include the input file's 'jp2c' box header in the output\n");
+    fprintf(output, "  --start <n>      Start extracting from the <n>th 'jp2c' box\n");
+    fprintf(output, "  --count <n>      Extract at most <n> 'jp2c' boxes\n");
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -369,7 +373,7 @@ int main(int argc, const char **argv)
     int result = 0;
 
     if (argc <= 1) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 0);
         return 0;
     }
 
@@ -377,7 +381,7 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "-h") == 0 ||
             strcmp(argv[cmdln_index], "--help") == 0)
         {
-            print_usage(argv[0]);
+            print_usage(argv[0], 0);
             return 0;
         }
         else if (strcmp(argv[cmdln_index], "--with-header") == 0)
@@ -387,12 +391,12 @@ int main(int argc, const char **argv)
         else if (strcmp(argv[cmdln_index], "--start") == 0)
         {
             if (cmdln_index + 1 >= argc) {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &start) != 1) {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid argument '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -401,12 +405,12 @@ int main(int argc, const char **argv)
         else if (strcmp(argv[cmdln_index], "--count") == 0)
         {
             if (cmdln_index + 1 >= argc) {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &count) != 1) {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid argument '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -419,17 +423,17 @@ int main(int argc, const char **argv)
     }
 
     if (cmdln_index + 2 < argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Unknown option '%s'\n", argv[cmdln_index]);
         return 1;
     }
     if (cmdln_index >= argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Missing <input filename> and <output filename>\n");
         return 1;
     }
     if (cmdln_index + 1 >= argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Missing <output filename>\n");
         return 1;
     }

--- a/tools/movdump.cpp
+++ b/tools/movdump.cpp
@@ -4160,15 +4160,19 @@ static void dump_file()
     }
 }
 
-static void usage(const char *cmd)
+static void usage(const char *cmd, bool error)
 {
-    fprintf(stderr, "Text dump Quicktime / MP4 files\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s [options] <quicktime filename>\n", cmd);
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, " -h | --help       Print this usage message and exit\n");
-    fprintf(stderr, "  --avcc <fname>   Write SPS and PPS NAL units in the 'avcC' box to <fname> file\n");
-    fprintf(stderr, "                   The NAL units are prefixed by a length word with size defined in the 'avcC' box\n");
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "Text dump Quicktime / MP4 files\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s [options] <quicktime filename>\n", cmd);
+    fprintf(output, "Options:\n");
+    fprintf(output, " -h | --help       Print this usage message and exit\n");
+    fprintf(output, "  --avcc <fname>   Write SPS and PPS NAL units in the 'avcC' box to <fname> file\n");
+    fprintf(output, "                   The NAL units are prefixed by a length word with size defined in the 'avcC' box\n");
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -4182,14 +4186,14 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "-h") == 0 ||
             strcmp(argv[cmdln_index], "--help") == 0)
         {
-            usage(argv[0]);
+            usage(argv[0], false);
             return 0;
         }
         else if (strcmp(argv[cmdln_index], "--avcc") == 0)
         {
             if (cmdln_index + 1 >= argc)
             {
-                usage(argv[0]);
+                usage(argv[0], true);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -4203,16 +4207,16 @@ int main(int argc, const char **argv)
     }
 
     if (cmdln_index + 1 < argc) {
-        usage(argv[0]);
+        usage(argv[0], true);
         fprintf(stderr, "Unknown argument '%s'\n", argv[cmdln_index]);
         return 1;
     }
     if (cmdln_index + 1 > argc) {
         if (argc == 1) {
-            usage(argv[0]);
+            usage(argv[0], false);
             return 0;
         }
-        usage(argv[0]);
+        usage(argv[0], true);
         fprintf(stderr, "Missing quicktime filename\n");
         return 1;
     }

--- a/tools/rdd36dump.c
+++ b/tools/rdd36dump.c
@@ -513,18 +513,22 @@ static int read_next_frame_offset(FILE *offsets_file, int64_t *offset_out)
     return 0;
 }
 
-static void print_usage(const char *cmd)
+static void print_usage(const char *cmd, int error)
 {
-    fprintf(stderr, "Text dump SMPTE RDD 36 (Apple ProRes) bitstream files\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s [options] <filename>\n", cmd);
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -h | --help        Show help and exit\n");
-    fprintf(stderr, "  --start <frame>    Skip <frame>s before dumping\n");
-    fprintf(stderr, "  --dur <frame>      Limit dump to <frame> count\n");
-    fprintf(stderr, "  --offsets <file>   Text file containing decimal file offsets for each frame separated by a newline\n");
-    fprintf(stderr, "                     E.g. using ffprobe to extract offsets from a Quicktime file:\n");
-    fprintf(stderr, "                       'ffprobe -show_packets -select_streams v:0 example.mov | grep pos >offsets.txt'\n");
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "Text dump SMPTE RDD 36 (Apple ProRes) bitstream files\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s [options] <filename>\n", cmd);
+    fprintf(output, "Options:\n");
+    fprintf(output, "  -h | --help        Show help and exit\n");
+    fprintf(output, "  --start <frame>    Skip <frame>s before dumping\n");
+    fprintf(output, "  --dur <frame>      Limit dump to <frame> count\n");
+    fprintf(output, "  --offsets <file>   Text file containing decimal file offsets for each frame separated by a newline\n");
+    fprintf(output, "                     E.g. using ffprobe to extract offsets from a Quicktime file:\n");
+    fprintf(output, "                       'ffprobe -show_packets -select_streams v:0 example.mov | grep pos >offsets.txt'\n");
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -542,7 +546,7 @@ int main(int argc, const char **argv)
     context.next_bit = -1;
 
     if (argc <= 1) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 0);
         return 0;
     }
 
@@ -550,20 +554,20 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "-h") == 0 ||
             strcmp(argv[cmdln_index], "--help") == 0)
         {
-            print_usage(argv[0]);
+            print_usage(argv[0], 0);
             return 0;
         }
         else if (strcmp(argv[cmdln_index], "--start") == 0)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &start) != 1 || start < 0)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -573,13 +577,13 @@ int main(int argc, const char **argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%" PRId64, &duration) != 1 || duration < 0)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -589,7 +593,7 @@ int main(int argc, const char **argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
@@ -603,12 +607,12 @@ int main(int argc, const char **argv)
     }
 
     if (cmdln_index + 1 < argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Unknown option '%s'\n", argv[cmdln_index]);
         return 1;
     }
     if (cmdln_index >= argc) {
-        print_usage(argv[0]);
+        print_usage(argv[0], 1);
         fprintf(stderr, "Missing <filename>\n");
         return 1;
     }

--- a/tools/vc2dump.c
+++ b/tools/vc2dump.c
@@ -1293,16 +1293,20 @@ static int parse_vc2()
     return 1;
 }
 
-static void print_usage(const char *cmd)
+static void print_usage(const char *cmd, int error)
 {
-    fprintf(stderr, "Text dump SMPTE ST 2042 VC-2 bitstream files\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: %s [options] [<filename>]\n", cmd);
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -h | --help      Show help and exit\n");
-    fprintf(stderr, "  --show-pict <n>  Print the first <n> unparsed bytes of the Picture data. Defaults to %d\n", DEFAULT_SHOW_PICT);
-    fprintf(stderr, "  --show-aux <n>   Print the first <n> bytes of the Auxiliary data. Defaults to %d\n", DEFAULT_SHOW_AUX);
-    fprintf(stderr, "  --show-pad <n>   Print the first <n> bytes of the Padding data. Defaults to %d\n", DEFAULT_SHOW_PAD);
+    FILE *output = error ? stderr: stdout;
+
+    fprintf(output, "Text dump SMPTE ST 2042 VC-2 bitstream files\n");
+    fprintf(output, "\n");
+    fprintf(output, "Usage: %s [options] [<filename>]\n", cmd);
+    fprintf(output, "Options:\n");
+    fprintf(output, "  -h | --help      Show help and exit\n");
+    fprintf(output, "  --show-pict <n>  Print the first <n> unparsed bytes of the Picture data. Defaults to %d\n", DEFAULT_SHOW_PICT);
+    fprintf(output, "  --show-aux <n>   Print the first <n> bytes of the Auxiliary data. Defaults to %d\n", DEFAULT_SHOW_AUX);
+    fprintf(output, "  --show-pad <n>   Print the first <n> bytes of the Padding data. Defaults to %d\n", DEFAULT_SHOW_PAD);
+    if (error)
+        fprintf(output, "\n");
 }
 
 int main(int argc, const char **argv)
@@ -1317,20 +1321,20 @@ int main(int argc, const char **argv)
         if (strcmp(argv[cmdln_index], "-h") == 0 ||
             strcmp(argv[cmdln_index], "--help") == 0)
         {
-            print_usage(argv[0]);
+            print_usage(argv[0], 0);
             return 0;
         }
         else if (strcmp(argv[cmdln_index], "--show-pict") == 0)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &state.show_pict) != 1)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1340,13 +1344,13 @@ int main(int argc, const char **argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &state.show_aux) != 1)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1356,13 +1360,13 @@ int main(int argc, const char **argv)
         {
             if (cmdln_index + 1 >= argc)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Missing argument for option '%s'\n", argv[cmdln_index]);
                 return 1;
             }
             if (sscanf(argv[cmdln_index + 1], "%d", &state.show_pad) != 1)
             {
-                print_usage(argv[0]);
+                print_usage(argv[0], 1);
                 fprintf(stderr, "Invalid value '%s' for option '%s'\n", argv[cmdln_index + 1], argv[cmdln_index]);
                 return 1;
             }
@@ -1375,7 +1379,7 @@ int main(int argc, const char **argv)
     }
     if (cmdln_index < argc) {
         if (cmdln_index + 1 < argc) {
-            print_usage(argv[0]);
+            print_usage(argv[0], 1);
             fprintf(stderr, "Unknown option '%s'\n", argv[cmdln_index]);
             return 1;
         }


### PR DESCRIPTION
This allows it to be viewed using `<cmd> -h | less` for example.

Output a short reference to the usage on error for the apps with long usages: bmxtranswrap, raw2bmx and mxf2raw

Shorten the command name shown in the apps usage.