### PR TITLE
ARGs in the bmx Dockerfile allow anybody to customize the make instal…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,15 @@ RUN DEBIAN_FRONTEND=noninteractive \
 
 # Copy, configure and make install
 COPY . bmx
+ARG BUILD_SHARED_LIBS=ON
+ARG LIBMXF_BUILD_ARCHIVE=ON
+ARG BMX_BUILD_WITH_LIBCURL=ON
 RUN mkdir build && cd build && \
     cmake -G "Unix Makefiles" \
         -DCMAKE_INSTALL_PREFIX=/build/install \
-        -DBMX_BUILD_WITH_LIBCURL=ON \
-        -DLIBMXF_BUILD_ARCHIVE=ON \
+        -DBMX_BUILD_WITH_LIBCURL=$BMX_BUILD_WITH_LIBCURL \
+        -DLIBMXF_BUILD_ARCHIVE=$LIBMXF_BUILD_ARCHIVE \
+        -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
         ../bmx && \
     make && make test && make install
 


### PR DESCRIPTION
ARGs in the bmx Dockerfile allow anybody to customize the make install step:

docker build --build-arg BUILD_SHARED_LIBS=OFF our-registry/bmxtools .