### PR TITLE
Add available precharge and rollout info

### DIFF
--- a/apps/mxf2raw/mxf2raw.cpp
+++ b/apps/mxf2raw/mxf2raw.cpp
@@ -812,10 +812,14 @@ static void write_track_info(AppInfoWriter *info_writer, MXFReader *reader, MXFT
     const MXFDataTrackInfo *data_info = dynamic_cast<const MXFDataTrackInfo*>(track_info);
 
     int16_t precharge = 0;
+    int64_t available_precharge = 0;
     int16_t rollout = 0;
+    int64_t available_rollout = 0;
     if (reader->IsComplete() && track_reader->GetDuration() > 0) {
         precharge = track_reader->GetPrecharge(0, true);
+        available_precharge = track_reader->GetAvailablePrecharge(0);
         rollout = track_reader->GetRollout(track_reader->GetDuration() - 1, true);
+        available_rollout = track_reader->GetAvailableRollout(track_reader->GetDuration() - 1);
     }
 
     info_writer->WriteEnumStringItem("essence_kind", ESSENCE_KIND_EINFO, track_info->data_def);
@@ -831,8 +835,12 @@ static void write_track_info(AppInfoWriter *info_writer, MXFReader *reader, MXFT
     }
     if (precharge != 0)
         info_writer->WriteIntegerItem("precharge", precharge);
+    if (available_precharge != 0)
+        info_writer->WriteIntegerItem("available_precharge", available_precharge);
     if (rollout != 0)
         info_writer->WriteIntegerItem("rollout", rollout);
+    if (available_rollout != 0)
+        info_writer->WriteIntegerItem("available_rollout", available_rollout);
     if (checksums) {
         size_t i;
         for (i = 0; i < checksums->size(); i++) {
@@ -1032,10 +1040,14 @@ static void write_clip_info(AppInfoWriter *info_writer, MXFReader *reader,
     bool have_track_crc32_data = (track_crc32_data.size() == reader->GetNumTrackReaders());
 
     int16_t max_precharge = 0;
+    int64_t max_available_precharge = 0;
     int16_t max_rollout = 0;
+    int64_t max_available_rollout = 0;
     if (reader->IsComplete() && reader->GetDuration() > 0) {
         max_precharge = reader->GetMaxPrecharge(0, false);
+        max_available_precharge = reader->GetMaxAvailablePrecharge(0);
         max_rollout = reader->GetMaxRollout(reader->GetDuration() - 1, false);
+        max_available_rollout = reader->GetMaxAvailableRollout(reader->GetDuration() - 1);
     }
 
     string clip_name = reader->GetMaterialPackageName();
@@ -1046,8 +1058,12 @@ static void write_clip_info(AppInfoWriter *info_writer, MXFReader *reader,
     info_writer->WriteDurationItem("duration", reader->GetDuration(), edit_rate);
     if (max_precharge != 0)
         info_writer->WriteIntegerItem("max_precharge", max_precharge);
+    if (max_available_precharge != 0)
+        info_writer->WriteIntegerItem("max_available_precharge", max_available_precharge);
     if (max_rollout != 0)
         info_writer->WriteIntegerItem("max_rollout", max_rollout);
+    if (max_available_rollout != 0)
+        info_writer->WriteIntegerItem("max_available_rollout", max_available_rollout);
 
     // Write Primary Package if it's a single (main) file only
     MXFFileReader *file_reader = dynamic_cast<MXFFileReader*>(reader);

--- a/include/bmx/mxf_reader/MXFFileReader.h
+++ b/include/bmx/mxf_reader/MXFFileReader.h
@@ -129,7 +129,9 @@ public:
     virtual int64_t GetPosition() const;
 
     virtual int16_t GetMaxPrecharge(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetMaxAvailablePrecharge(int64_t position) const;
     virtual int16_t GetMaxRollout(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetMaxAvailableRollout(int64_t position) const;
 
 public:
     virtual int64_t GetFixedLeadFillerOffset() const;
@@ -207,7 +209,9 @@ private:
 
     bool GetInternalIndexEntry(MXFIndexEntryExt *entry, int64_t position) const;
     int16_t GetInternalPrecharge(int64_t position, bool limit_to_available) const;
+    int64_t GetInternalAvailablePrecharge(int64_t position) const;
     int16_t GetInternalRollout(int64_t position, bool limit_to_available) const;
+    int64_t GetInternalAvailableRollout(int64_t position) const;
     void GetInternalAvailableReadLimits(int64_t *start_position, int64_t *duration) const;
 
     bool HaveInterFrameEncodingTrack() const;

--- a/include/bmx/mxf_reader/MXFFileTrackReader.h
+++ b/include/bmx/mxf_reader/MXFFileTrackReader.h
@@ -76,7 +76,9 @@ public:
     virtual bool GetIndexEntry(MXFIndexEntryExt *entry, int64_t position = CURRENT_POSITION_VALUE) const;
 
     virtual int16_t GetPrecharge(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetAvailablePrecharge(int64_t position) const;
     virtual int16_t GetRollout(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetAvailableRollout(int64_t position) const;
 
     virtual MXFTrackInfo* GetTrackInfo() const { return mTrackInfo; }
     virtual mxfpp::FileDescriptor* GetFileDescriptor() const { return mFileDescriptor; }

--- a/include/bmx/mxf_reader/MXFGroupReader.h
+++ b/include/bmx/mxf_reader/MXFGroupReader.h
@@ -73,7 +73,9 @@ public:
     virtual int64_t GetPosition() const;
 
     virtual int16_t GetMaxPrecharge(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetMaxAvailablePrecharge(int64_t position) const;
     virtual int16_t GetMaxRollout(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetMaxAvailableRollout(int64_t position) const;
 
 public:
     virtual int64_t GetFixedLeadFillerOffset() const;

--- a/include/bmx/mxf_reader/MXFReader.h
+++ b/include/bmx/mxf_reader/MXFReader.h
@@ -93,8 +93,14 @@ public:
 
     virtual int64_t GetPosition() const = 0;
 
+    // Returns the maximum precharge required for the given position.
     virtual int16_t GetMaxPrecharge(int64_t position, bool limit_to_available) const = 0;
+    // Returns the maximum precharge available before the given position.
+    virtual int64_t GetMaxAvailablePrecharge(int64_t position) const = 0;
+    // Returns the maximum rollout required for the given position.
     virtual int16_t GetMaxRollout(int64_t position, bool limit_to_available) const = 0;
+    // Returns the maximum rollout available after the given position.
+    virtual int64_t GetMaxAvailableRollout(int64_t position) const = 0;
 
     mxfRational GetEditRate() const   { return mEditRate; }
     int64_t GetDuration() const       { return mDuration; }

--- a/include/bmx/mxf_reader/MXFSequenceReader.h
+++ b/include/bmx/mxf_reader/MXFSequenceReader.h
@@ -76,7 +76,9 @@ public:
     virtual int64_t GetPosition() const { return mPosition; }
 
     virtual int16_t GetMaxPrecharge(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetMaxAvailablePrecharge(int64_t position) const;
     virtual int16_t GetMaxRollout(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetMaxAvailableRollout(int64_t position) const;
 
 public:
     virtual int64_t GetFixedLeadFillerOffset() const;

--- a/include/bmx/mxf_reader/MXFSequenceTrackReader.h
+++ b/include/bmx/mxf_reader/MXFSequenceTrackReader.h
@@ -87,7 +87,9 @@ public:
     virtual bool GetIndexEntry(MXFIndexEntryExt *entry, int64_t position = CURRENT_POSITION_VALUE) const;
 
     virtual int16_t GetPrecharge(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetAvailablePrecharge(int64_t position) const;
     virtual int16_t GetRollout(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetAvailableRollout(int64_t position) const;
 
     virtual MXFTrackInfo* GetTrackInfo() const                 { return mTrackInfo; }
     virtual mxfpp::FileDescriptor* GetFileDescriptor() const   { return mFileDescriptor; }

--- a/include/bmx/mxf_reader/MXFTimedTextTrackReader.h
+++ b/include/bmx/mxf_reader/MXFTimedTextTrackReader.h
@@ -48,6 +48,14 @@ public:
                             mxfpp::FileDescriptor *file_descriptor, mxfpp::SourcePackage *file_source_package);
     virtual ~MXFTimedTextTrackReader();
 
+    virtual int64_t GetOrigin() const;
+
+    virtual int16_t GetPrecharge(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetAvailablePrecharge(int64_t position) const;
+    virtual int16_t GetRollout(int64_t position, bool limit_to_available) const;
+    virtual int64_t GetAvailableRollout(int64_t position) const;
+
+public:
     void SetBodySID(uint32_t body_sid);
 
     TimedTextManifest* GetManifest();

--- a/include/bmx/mxf_reader/MXFTrackReader.h
+++ b/include/bmx/mxf_reader/MXFTrackReader.h
@@ -82,8 +82,14 @@ public:
 
     virtual bool GetIndexEntry(MXFIndexEntryExt *entry, int64_t position = CURRENT_POSITION_VALUE) const = 0;
 
+    // Returns the precharge required for the given position.
     virtual int16_t GetPrecharge(int64_t position, bool limit_to_available) const = 0;
+    // Returns the precharge available before the given position.
+    virtual int64_t GetAvailablePrecharge(int64_t position) const = 0;
+    // Returns the rollout required for the given position.
     virtual int16_t GetRollout(int64_t position, bool limit_to_available) const = 0;
+    // Returns the rollout available after the given position.
+    virtual int64_t GetAvailableRollout(int64_t position) const = 0;
 
     virtual MXFTrackInfo* GetTrackInfo() const = 0;
     virtual mxfpp::FileDescriptor* GetFileDescriptor() const = 0;

--- a/meta/mxf2raw/mxf2raw_info.xsd
+++ b/meta/mxf2raw/mxf2raw_info.xsd
@@ -215,7 +215,9 @@
       <xs:element name="edit_rate" type="rational_type"/>
       <xs:element name="duration" type="duration_type"/>
       <xs:element name="max_precharge" type="int16_type" minOccurs="0"/>
+      <xs:element name="max_available_precharge" type="int64_type" minOccurs="0"/>
       <xs:element name="max_rollout" type="int16_type" minOccurs="0"/>
+      <xs:element name="max_available_rollout" type="int64_type" minOccurs="0"/>
       <xs:element name="primary_package" type="primary_package_type" minOccurs="0"/>
       <xs:element name="start_timecodes" type="start_timecodes_type"/>
       <xs:element name="tracks" type="tracks_type"/>
@@ -265,7 +267,9 @@
           <xs:element name="lead_filler_offset" type="position_type" minOccurs="0"/>
           <xs:element name="timed_text_offset" type="position_type" minOccurs="0"/>
           <xs:element name="precharge" type="int16_type" minOccurs="0"/>
+          <xs:element name="available_precharge" type="int64_type" minOccurs="0"/>
           <xs:element name="rollout" type="int16_type" minOccurs="0"/>
+          <xs:element name="available_rollout" type="int64_type" minOccurs="0"/>
           <xs:element name="checksum" type="checksum_type" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="crc32_check" type="crc32_check_type" minOccurs="0"/>
           <xs:element name="packages" type="track_packages_type"/>

--- a/src/mxf_reader/MXFFileTrackReader.cpp
+++ b/src/mxf_reader/MXFFileTrackReader.cpp
@@ -173,9 +173,19 @@ int16_t MXFFileTrackReader::GetPrecharge(int64_t position, bool limit_to_availab
     return mFileReader->GetInternalPrecharge(position, limit_to_available);
 }
 
+int64_t MXFFileTrackReader::GetAvailablePrecharge(int64_t position) const
+{
+    return mFileReader->GetInternalAvailablePrecharge(position);
+}
+
 int16_t MXFFileTrackReader::GetRollout(int64_t position, bool limit_to_available) const
 {
     return mFileReader->GetInternalRollout(position, limit_to_available);
+}
+
+int64_t MXFFileTrackReader::GetAvailableRollout(int64_t position) const
+{
+    return mFileReader->GetInternalAvailableRollout(position);
 }
 
 void MXFFileTrackReader::SetNextFramePosition(Rational edit_rate, int64_t position)

--- a/src/mxf_reader/MXFSequenceReader.cpp
+++ b/src/mxf_reader/MXFSequenceReader.cpp
@@ -666,6 +666,27 @@ int16_t MXFSequenceReader::GetMaxPrecharge(int64_t position, bool limit_to_avail
     return segment->GetMaxPrecharge(segment_position, limit_to_available);
 }
 
+int64_t MXFSequenceReader::GetMaxAvailablePrecharge(int64_t position) const
+{
+    BMX_CHECK(!mGroupSegments.empty());
+
+    int64_t target_position = position;
+    if (target_position == CURRENT_POSITION_VALUE)
+        target_position = GetPosition();
+
+    MXFGroupReader *segment;
+    size_t segment_index;
+    int64_t segment_position;
+    GetSegmentPosition(0, &segment, &segment_index, &segment_position);
+
+    int64_t available_at_start = segment->GetMaxAvailablePrecharge(segment_position);
+    int64_t max_available_precharge = available_at_start - target_position;
+    if (max_available_precharge > 0)
+        max_available_precharge = 0;
+
+    return max_available_precharge;
+}
+
 int16_t MXFSequenceReader::GetMaxRollout(int64_t position, bool limit_to_available) const
 {
     BMX_CHECK(!mGroupSegments.empty());
@@ -676,6 +697,27 @@ int16_t MXFSequenceReader::GetMaxRollout(int64_t position, bool limit_to_availab
     GetSegmentPosition(position, &segment, &segment_index, &segment_position);
 
     return segment->GetMaxRollout(segment_position, limit_to_available);
+}
+
+int64_t MXFSequenceReader::GetMaxAvailableRollout(int64_t position) const
+{
+    BMX_CHECK(!mGroupSegments.empty());
+
+    int64_t target_position = position;
+    if (target_position == CURRENT_POSITION_VALUE)
+        target_position = GetPosition();
+
+    MXFGroupReader *segment;
+    size_t segment_index;
+    int64_t segment_position;
+    GetSegmentPosition(mDuration - 1, &segment, &segment_index, &segment_position);
+
+    int64_t available_at_end = segment->GetMaxAvailableRollout(segment_position);
+    int64_t max_available_rollout = (mDuration - 1) + available_at_end - target_position;
+    if (max_available_rollout < 0)
+        max_available_rollout = 0;
+
+    return max_available_rollout;
 }
 
 int64_t MXFSequenceReader::GetFixedLeadFillerOffset() const

--- a/src/mxf_reader/MXFSequenceTrackReader.cpp
+++ b/src/mxf_reader/MXFSequenceTrackReader.cpp
@@ -361,6 +361,26 @@ int16_t MXFSequenceTrackReader::GetPrecharge(int64_t position, bool limit_to_ava
     return segment->GetPrecharge(segment_position, limit_to_available);
 }
 
+int64_t MXFSequenceTrackReader::GetAvailablePrecharge(int64_t position) const
+{
+    BMX_CHECK(!mTrackSegments.empty());
+
+    int64_t target_position = position;
+    if (target_position == CURRENT_POSITION_VALUE)
+        target_position = GetPosition();
+
+    MXFTrackReader *segment;
+    int64_t segment_position;
+    GetSegmentPosition(0, &segment, &segment_position);
+
+    int64_t available_at_start = segment->GetAvailablePrecharge(segment_position);
+    int64_t available_precharge = available_at_start - target_position;
+    if (available_precharge > 0)
+        available_precharge = 0;
+
+    return available_precharge;
+}
+
 int16_t MXFSequenceTrackReader::GetRollout(int64_t position, bool limit_to_available) const
 {
     BMX_CHECK(!mTrackSegments.empty());
@@ -370,6 +390,26 @@ int16_t MXFSequenceTrackReader::GetRollout(int64_t position, bool limit_to_avail
     GetSegmentPosition(position, &segment, &segment_position);
 
     return segment->GetRollout(segment_position, limit_to_available);
+}
+
+int64_t MXFSequenceTrackReader::GetAvailableRollout(int64_t position) const
+{
+    BMX_CHECK(!mTrackSegments.empty());
+
+    int64_t target_position = position;
+    if (target_position == CURRENT_POSITION_VALUE)
+        target_position = GetPosition();
+
+    MXFTrackReader *segment;
+    int64_t segment_position;
+    GetSegmentPosition(mDuration - 1, &segment, &segment_position);
+
+    int64_t available_at_end = segment->GetAvailableRollout(segment_position);
+    int64_t available_rollout = (mDuration - 1) + available_at_end - target_position;
+    if (available_rollout < 0)
+        available_rollout = 0;
+
+    return available_rollout;
 }
 
 void MXFSequenceTrackReader::SetNextFramePosition(Rational edit_rate, int64_t position)

--- a/src/mxf_reader/MXFTimedTextTrackReader.cpp
+++ b/src/mxf_reader/MXFTimedTextTrackReader.cpp
@@ -64,6 +64,42 @@ MXFTimedTextTrackReader::~MXFTimedTextTrackReader()
 {
 }
 
+int64_t MXFTimedTextTrackReader::GetOrigin() const
+{
+    // MXFFileReader would throw a MXF_RESULT_NOT_SUPPORTED if origin != 0
+    return 0;
+}
+
+int16_t MXFTimedTextTrackReader::GetPrecharge(int64_t position, bool limit_to_available) const
+{
+    (void)position;
+    (void)limit_to_available;
+    return 0;
+}
+
+int64_t MXFTimedTextTrackReader::GetAvailablePrecharge(int64_t position) const
+{
+    if (position < 0)
+        return 0;
+    else
+        return - position;
+}
+
+int16_t MXFTimedTextTrackReader::GetRollout(int64_t position, bool limit_to_available) const
+{
+    (void)position;
+    (void)limit_to_available;
+    return 0;
+}
+
+int64_t MXFTimedTextTrackReader::GetAvailableRollout(int64_t position) const
+{
+    if (position >= GetDuration())
+        return 0;
+    else
+        return GetDuration() - 1 - position;
+}
+
 void MXFTimedTextTrackReader::SetBodySID(uint32_t body_sid)
 {
     mBodySID = body_sid;

--- a/test/timed_text/info_7.xml.bin
+++ b/test/timed_text/info_7.xml.bin
@@ -50,6 +50,7 @@
   <clip>
     <edit_rate>25/1</edit_rate>
     <duration count="8">00:00:00:08</duration>
+    <max_available_precharge>-4</max_available_precharge>
     <start_timecodes>
       <material>09:59:59:24</material>
       <file_source>09:59:59:24</file_source>
@@ -61,6 +62,7 @@
         <ec_label>urn:smpte:ul:060e2b34.04010102.0d010301.02046001</ec_label>
         <edit_rate>25/1</edit_rate>
         <duration count="8">00:00:00:08</duration>
+        <available_precharge>-4</available_precharge>
         <packages size="1">
           <package index="0">
             <material>


### PR DESCRIPTION
This PR adds these optional properties to the mxf2raw clip section:
* `max_available_precharge`
  * Is the maximum number of available edit units (expressed as a negative number) before clip position 0 of all tracks in the clip
  * A larger (negative) `max_available_precharge` compared with `max_precharge` means there are more edit units available than strictly necessary to produce the output
* `max_available_rollout`
  * Is the maximum number of available edit units (expressed as a positive number) after clip position `clip duration - 1` of all tracks in the clip
  * A larger `max_available_rollout` compared with `max_rollout` means there are more edit units available than strictly necessary to produce the output

This PR also adds these optional properties to the mxf2raw track section:
* `available_precharge`
  * Is the number of available edit units (expressed as a negative number) before track position 0
  * A larger (negative) `available_precharge` compared with `precharge` means there are more edit units available than strictly necessary to produce the output
* `available_rollout`
  * Is the number of available edit units (expressed as a positive number) after track position `track duration - 1`
  * A larger `available_rollout` compared with `rollout` means there are more edit units available than strictly necessary to produce the output

This example file from https://github.com/bbc/bmx/discussions/23 produces this output:
```
...
Clip
  edit_rate       : 25/1
  duration        : 00:01:59:02 (count='2977')
  max_precharge   : -2
  max_available_precharge : -14
...
    Track #0:
      essence_kind    : Picture
      essence_type    : MPEG_2_Long_GOP_422P_HL_1080i
      ec_label        : urn:smpte:ul:060e2b34.04010102.0d010301.02046001
      edit_rate       : 25/1
      duration        : 00:01:59:02 (count='2977')
      precharge       : -2
      available_precharge : -14
...
```
2 edit units are necessary to produce the output (the `max_precharge` and `precharge`). 14 edit units are available (the `max_available_precharge` and `available_precharge`).