### PR TITLE
Don't include "manufacturer" attribute in RDD 6 XML output

### DIFF
--- a/meta/rdd6/rdd6.xsd
+++ b/meta/rdd6/rdd6.xsd
@@ -60,7 +60,15 @@
   <xs:complexType name="orig_id_type">
     <xs:simpleContent>
       <xs:extension base="hex_uint8_type">
-        <xs:attribute name="manufacturer" type="xs:string" use="optional"/>
+        <xs:attribute name="manufacturer" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              The manufacturer string attribute may be included here for known integer values,
+              but note that it is not part in the RDD 6 serial bitstream.
+              This attribute may be removed in future.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>

--- a/src/st436/RDD6Metadata.cpp
+++ b/src/st436/RDD6Metadata.cpp
@@ -1595,10 +1595,6 @@ void RDD6MetadataSubFrame::UnparseXML(XMLWriter *writer) const
     writer->WriteElementStart(RDD6_NAMESPACE, "sync");
     writer->WriteElement(RDD6_NAMESPACE, "rev_id", unparse_xml_hex_uint8(sync_segment.revision_id));
     writer->WriteElementStart(RDD6_NAMESPACE, "orig_id");
-    if (sync_segment.originator_id >= 1 && sync_segment.originator_id <= 32)
-        writer->WriteAttribute(RDD6_NAMESPACE, "manufacturer", "Dolby Laboratories");
-    else if (sync_segment.originator_id >= 33 && sync_segment.originator_id <= 42)
-        writer->WriteAttribute(RDD6_NAMESPACE, "manufacturer", "Harris Broadcast Communications (Leitch)");
     writer->WriteElementContent(unparse_xml_hex_uint8(sync_segment.originator_id));
     writer->WriteElementEnd();
     if (sync_segment.originator_id != 0) {

--- a/test/rdd6/test1.xml.bin
+++ b/test/rdd6/test1.xml.bin
@@ -3,7 +3,7 @@
   <first_subframe>
     <sync>
       <rev_id>0x00</rev_id>
-      <orig_id manufacturer="Dolby Laboratories">0x01</orig_id>
+      <orig_id>0x01</orig_id>
       <orig_addr>0x0000</orig_addr>
       <frame_count>3000</frame_count>
     </sync>
@@ -47,7 +47,7 @@
   <second_subframe>
     <sync>
       <rev_id>0x00</rev_id>
-      <orig_id manufacturer="Dolby Laboratories">0x01</orig_id>
+      <orig_id>0x01</orig_id>
       <orig_addr>0x0000</orig_addr>
       <frame_count>3000</frame_count>
     </sync>

--- a/test/rdd6/test2.xml.bin
+++ b/test/rdd6/test2.xml.bin
@@ -3,7 +3,7 @@
   <first_subframe>
     <sync>
       <rev_id>0x00</rev_id>
-      <orig_id manufacturer="Dolby Laboratories">0x01</orig_id>
+      <orig_id>0x01</orig_id>
       <orig_addr>0x0000</orig_addr>
       <frame_count>3000</frame_count>
     </sync>
@@ -53,7 +53,7 @@
   <second_subframe>
     <sync>
       <rev_id>0x00</rev_id>
-      <orig_id manufacturer="Dolby Laboratories">0x01</orig_id>
+      <orig_id>0x01</orig_id>
       <orig_addr>0x0000</orig_addr>
       <frame_count>3000</frame_count>
     </sync>

--- a/test/rdd6/test3.xml.bin
+++ b/test/rdd6/test3.xml.bin
@@ -3,7 +3,7 @@
   <first_subframe>
     <sync>
       <rev_id>0x00</rev_id>
-      <orig_id manufacturer="Dolby Laboratories">0x01</orig_id>
+      <orig_id>0x01</orig_id>
       <orig_addr>0x0000</orig_addr>
       <frame_count>3000</frame_count>
     </sync>
@@ -53,7 +53,7 @@
   <second_subframe>
     <sync>
       <rev_id>0x00</rev_id>
-      <orig_id manufacturer="Dolby Laboratories">0x01</orig_id>
+      <orig_id>0x01</orig_id>
       <orig_addr>0x0000</orig_addr>
       <frame_count>3000</frame_count>
     </sync>


### PR DESCRIPTION
mxf2raw will no longer include it in the RDD 6 XML it outputs. bmxtranswrap and raw2bmx will continue to ignore it and the XML Schema still allows it to be present.

The "manufacturer" string attribute was included for known integer values, but it is not part in the RDD 6 serial bitstream.

This attribute may be removed in future.