### PR TITLE
Some build modifications

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,11 +23,23 @@ jobs:
               -DBMX_TEST_WITH_VALGRIND=ON
               -DLIBMXF_TEST_WITH_VALGRIND=ON
               -DLIBMXFPP_TEST_WITH_VALGRIND=ON
-          - name: macos
+          - name: macos-brew
             os: macos-latest
             cmake_config_args: >-
               -DCMAKE_BUILD_TYPE=Debug
               -DBMX_BUILD_WITH_LIBCURL=ON
+          - name: macos-xcode-universal
+            os: macos-latest
+            cmake_config_args: >-
+              -G Xcode
+              -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+              -DBUILD_SHARED_LIBS=OFF
+              -DBMX_BUILD_URIPARSER_SOURCE=ON
+              -DBMX_BUILD_WITH_LIBCURL=ON
+            cmake_build_args: >-
+              --config Debug
+            cmake_test_args: >-
+              -C Debug
           - name: windows
             os: windows-latest
             cmake_build_args: >-
@@ -38,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install dependencies (Ubuntu)
+      - name: Install dependencies (ubuntu)
         if: ${{ contains(matrix.os, 'ubuntu') }}
         shell: bash
         run: |
@@ -54,11 +66,18 @@ jobs:
             liburiparser-dev \
             libexpat1-dev \
             libcurl4-openssl-dev
-      - name: Install dependencies (MacOS)
-        if: ${{ contains(matrix.os, 'macos') }}
+
+      - name: Install dependencies (macos-brew)
+        if: ${{ matrix.name == 'macos-brew' }}
         shell: bash
         run: |
           brew install git cmake expat uriparser curl
+
+      - name: Install dependencies (macos-xcode-universal)
+        if: ${{ matrix.name == 'macos-xcode-universal' }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Show Versions
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,11 @@ if(MSVC AND BMX_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
 
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS OR NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
     # Ensure that static library code can be linked into the dynamic libraries (-fPIC compile option)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
+
 set(CMAKE_CXX_STANDARD 11)
 
 # Set the test samples output directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,12 @@ project(bmx
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
-if(MSVC AND BMX_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
-    # cmake version >= 3.15: Use MultiThreadedDLL runtime
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+if(MSVC AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
+    if(BMX_SET_MSVC_RUNTIME STREQUAL "MD")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    elseif(BMX_SET_MSVC_RUNTIME STREQUAL "MT")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
 endif()
 
 if(BUILD_SHARED_LIBS OR NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
@@ -45,10 +48,16 @@ if(MSVC)
     add_compile_options(/W3 /EHsc)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    if(BMX_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_LESS 3.15.0)
-        # cmake version < 3.15: Update compiler flags to use the MultiThreadedDLL runtime
+    if(CMAKE_VERSION VERSION_LESS 3.15.0 AND NOT BMX_SET_MSVC_RUNTIME STREQUAL "default")
+        # cmake version < 3.15: Update compiler flags to use a particular runtime
         macro(update_msvc_runtime_flags flags)
-            string(REGEX REPLACE "/MT" "/MD" ${flags} "${${flags}}")
+            if(BMX_SET_MSVC_RUNTIME STREQUAL "MD")
+                # Use MultiThreadedDLL runtime
+                string(REGEX REPLACE "/MT" "/MD" ${flags} "${${flags}}")
+            elseif(BMX_SET_MSVC_RUNTIME STREQUAL "MT")
+                # Use MultiThreaded runtime
+                string(REGEX REPLACE "/MD" "/MT" ${flags} "${${flags}}")
+            endif()
         endmacro()
 
         update_msvc_runtime_flags(CMAKE_C_FLAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
-    # Set policy CMP0091 to new to allow use of CMAKE_MSVC_RUNTIME_LIBRARY
-    cmake_policy(SET CMP0091 NEW)
+# Set the policy CMP0091 to new to allow use of CMAKE_MSVC_RUNTIME_LIBRARY,
+# unless it has already been set
+if(POLICY CMP0091)
+    cmake_policy(GET CMP0091 CMP0091_value)
+    if(NOT CMP0091_value)
+        cmake_policy(SET CMP0091 NEW)
+        cmake_policy(GET CMP0091 CMP0091_value)
+    endif()
+else()
+    set(CMP0091_value OLD)
 endif()
 
 project(bmx
@@ -14,7 +21,7 @@ project(bmx
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
-if(MSVC AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
+if(MSVC AND CMP0091_value STREQUAL NEW)
     if(BMX_SET_MSVC_RUNTIME STREQUAL "MD")
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     elseif(BMX_SET_MSVC_RUNTIME STREQUAL "MT")
@@ -48,8 +55,8 @@ if(MSVC)
     add_compile_options(/W3 /EHsc)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    if(CMAKE_VERSION VERSION_LESS 3.15.0 AND NOT BMX_SET_MSVC_RUNTIME STREQUAL "default")
-        # cmake version < 3.15: Update compiler flags to use a particular runtime
+    if(CMP0091_value STREQUAL OLD AND NOT BMX_SET_MSVC_RUNTIME STREQUAL "default")
+        # Update compiler flags to use a particular runtime
         macro(update_msvc_runtime_flags flags)
             if(BMX_SET_MSVC_RUNTIME STREQUAL "MD")
                 # Use MultiThreadedDLL runtime

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -42,6 +42,7 @@ elseif(MSVC)
     # Shared library currently not supported
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build using shared libraries")
 
-    # Option to set to use the MultiThreadedDLL runtime
-    option(BMX_SET_MSVC_RUNTIME "Enable setting MSVC runtime to MultiThreadedDLL" ON)
+    # Option to set to use the runtime
+    set(BMX_SET_MSVC_RUNTIME "MD" CACHE STRING "Set MSVC debug/release runtime to 'MD' (MultiThreadedDLL), 'MT' (MultiThreaded) or 'default' (use the default)")
+    set_property(CACHE BMX_SET_MSVC_RUNTIME PROPERTY STRINGS MD MT default)
 endif()

--- a/deps/libMXF/CMakeLists.txt
+++ b/deps/libMXF/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
-    # Set policy CMP0091 to new to allow use of CMAKE_MSVC_RUNTIME_LIBRARY
-    cmake_policy(SET CMP0091 NEW)
+# Set the policy CMP0091 to new to allow use of CMAKE_MSVC_RUNTIME_LIBRARY,
+# unless it has already been set
+if(POLICY CMP0091)
+    cmake_policy(GET CMP0091 CMP0091_value)
+    if(NOT CMP0091_value)
+        cmake_policy(SET CMP0091 NEW)
+        cmake_policy(GET CMP0091 CMP0091_value)
+    endif()
+else()
+    set(CMP0091_value OLD)
 endif()
 
 project(libMXF
@@ -14,7 +21,7 @@ project(libMXF
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
-if(MSVC AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
+if(MSVC AND CMP0091_value STREQUAL NEW)
     if(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MD")
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     elseif(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MT")
@@ -48,8 +55,8 @@ if(MSVC)
     add_compile_options(/W3)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    if(CMAKE_VERSION VERSION_LESS 3.15.0 AND NOT LIBMXF_SET_MSVC_RUNTIME STREQUAL "default")
-        # cmake version < 3.15: Update compiler flags to use a particular runtime
+    if(CMP0091_value STREQUAL OLD AND NOT LIBMXF_SET_MSVC_RUNTIME STREQUAL default)
+        # Update compiler flags to use a particular runtime
         macro(update_msvc_runtime_flags flags)
             if(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MD")
                 # Use MultiThreadedDLL runtime

--- a/deps/libMXF/CMakeLists.txt
+++ b/deps/libMXF/CMakeLists.txt
@@ -14,9 +14,12 @@ project(libMXF
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
-if(MSVC AND LIBMXF_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
-    # cmake version >= 3.15: Use MultiThreadedDLL runtime
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+if(MSVC AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
+    if(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MD")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    elseif(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MT")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
 endif()
 
 if(BUILD_SHARED_LIBS OR NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
@@ -45,10 +48,16 @@ if(MSVC)
     add_compile_options(/W3)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    if(LIBMXF_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_LESS 3.15.0)
-        # cmake version < 3.15: Update compiler flags to use the MultiThreadedDLL runtime
+    if(CMAKE_VERSION VERSION_LESS 3.15.0 AND NOT LIBMXF_SET_MSVC_RUNTIME STREQUAL "default")
+        # cmake version < 3.15: Update compiler flags to use a particular runtime
         macro(update_msvc_runtime_flags flags)
-            string(REGEX REPLACE "/MT" "/MD" ${flags} "${${flags}}")
+            if(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MD")
+                # Use MultiThreadedDLL runtime
+                string(REGEX REPLACE "/MT" "/MD" ${flags} "${${flags}}")
+            elseif(LIBMXF_SET_MSVC_RUNTIME STREQUAL "MT")
+                # Use MultiThreaded runtime
+                string(REGEX REPLACE "/MD" "/MT" ${flags} "${${flags}}")
+            endif()
         endmacro()
 
         update_msvc_runtime_flags(CMAKE_C_FLAGS)

--- a/deps/libMXF/CMakeLists.txt
+++ b/deps/libMXF/CMakeLists.txt
@@ -19,10 +19,11 @@ if(MSVC AND LIBMXF_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
 
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS OR NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
     # Ensure that static library code can be linked into the dynamic libraries (-fPIC compile option)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
+
 set(CMAKE_CXX_STANDARD 11)
 
 # Set the test samples output directory

--- a/deps/libMXF/cmake/options.cmake
+++ b/deps/libMXF/cmake/options.cmake
@@ -45,6 +45,7 @@ elseif(MSVC)
     # Shared library currently not supported
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build using shared libraries")
 
-    # Option to set to use the MultiThreadedDLL runtime
-    option(LIBMXF_SET_MSVC_RUNTIME "Enable setting MSVC runtime to MultiThreadedDLL" ON)
+    # Option to set to use the runtime
+    set(LIBMXF_SET_MSVC_RUNTIME "MD" CACHE STRING "Set MSVC debug/release runtime to 'MD' (MultiThreadedDLL), 'MT' (MultiThreaded) or 'default' (use the default)")
+    set_property(CACHE LIBMXF_SET_MSVC_RUNTIME PROPERTY STRINGS MD MT default)
 endif()

--- a/deps/libMXFpp/CMakeLists.txt
+++ b/deps/libMXFpp/CMakeLists.txt
@@ -19,10 +19,11 @@ if(MSVC AND LIBMXFPP_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
 
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS OR NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
     # Ensure that static library code can be linked into the dynamic libraries (-fPIC compile option)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
+
 set(CMAKE_CXX_STANDARD 11)
 
 if(MSVC)

--- a/deps/libMXFpp/CMakeLists.txt
+++ b/deps/libMXFpp/CMakeLists.txt
@@ -14,9 +14,12 @@ project(libMXF++
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
-if(MSVC AND LIBMXFPP_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
-    # cmake version >= 3.15: Use MultiThreadedDLL runtime
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+if(MSVC AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
+    if(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MD")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    elseif(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MT")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
 endif()
 
 if(BUILD_SHARED_LIBS OR NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
@@ -30,10 +33,16 @@ if(MSVC)
     add_compile_options(/W3 /EHsc)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    if(LIBMXFPP_SET_MSVC_RUNTIME AND CMAKE_VERSION VERSION_LESS 3.15.0)
-        # cmake version < 3.15: Update compiler flags to use the MultiThreadedDLL runtime
+    if(CMAKE_VERSION VERSION_LESS 3.15.0 AND NOT LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "default")
+        # cmake version < 3.15: Update compiler flags to use a particular runtime
         macro(update_msvc_runtime_flags flags)
-            string(REGEX REPLACE "/MT" "/MD" ${flags} "${${flags}}")
+            if(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MD")
+                # Use MultiThreadedDLL runtime
+                string(REGEX REPLACE "/MT" "/MD" ${flags} "${${flags}}")
+            elseif(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MT")
+                # Use MultiThreaded runtime
+                string(REGEX REPLACE "/MD" "/MT" ${flags} "${${flags}}")
+            endif()
         endmacro()
 
         update_msvc_runtime_flags(CMAKE_C_FLAGS)

--- a/deps/libMXFpp/CMakeLists.txt
+++ b/deps/libMXFpp/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
-    # Set policy CMP0091 to new to allow use of CMAKE_MSVC_RUNTIME_LIBRARY
-    cmake_policy(SET CMP0091 NEW)
+# Set the policy CMP0091 to new to allow use of CMAKE_MSVC_RUNTIME_LIBRARY,
+# unless it has already been set
+if(POLICY CMP0091)
+    cmake_policy(GET CMP0091 CMP0091_value)
+    if(NOT CMP0091_value)
+        cmake_policy(SET CMP0091 NEW)
+        cmake_policy(GET CMP0091 CMP0091_value)
+    endif()
+else()
+    set(CMP0091_value OLD)
 endif()
 
 project(libMXF++
@@ -14,7 +21,7 @@ project(libMXF++
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
-if(MSVC AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.15.0)
+if(MSVC AND CMP0091_value STREQUAL NEW)
     if(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MD")
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     elseif(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MT")
@@ -33,8 +40,8 @@ if(MSVC)
     add_compile_options(/W3 /EHsc)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    if(CMAKE_VERSION VERSION_LESS 3.15.0 AND NOT LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "default")
-        # cmake version < 3.15: Update compiler flags to use a particular runtime
+    if(CMP0091_value STREQUAL OLD AND NOT LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "default")
+        # Update compiler flags to use a particular runtime
         macro(update_msvc_runtime_flags flags)
             if(LIBMXFPP_SET_MSVC_RUNTIME STREQUAL "MD")
                 # Use MultiThreadedDLL runtime

--- a/deps/libMXFpp/cmake/options.cmake
+++ b/deps/libMXFpp/cmake/options.cmake
@@ -33,6 +33,7 @@ elseif(MSVC)
     # Shared library currently not supported
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build using shared libraries")
 
-    # Option to set to use the MultiThreadedDLL runtime
-    option(LIBMXFPP_SET_MSVC_RUNTIME "Enable setting MSVC runtime to MultiThreadedDLL" ON)
+    # Option to set to use the runtime
+    set(LIBMXFPP_SET_MSVC_RUNTIME "MD" CACHE STRING "Set MSVC debug/release runtime to 'MD' (MultiThreadedDLL), 'MT' (MultiThreaded) or 'default' (use the default)")
+    set_property(CACHE LIBMXFPP_SET_MSVC_RUNTIME PROPERTY STRINGS MD MT default)
 endif()


### PR DESCRIPTION
This PR
* adds an action to build a MacOS Universal Binary using XCode
* Defaults to position independent code, whether building shared or static libraries
* Changes the *_SET_MSVC_RUNTIME option to be a string with value "MD"  (MultiThreadedDLL) "MT" (MultiThreaded) or "default" (the CMAKE default, which is "MD"). The "d" for debug is added automatically.