### PR TITLE
cmake: use gnuinstalldirs and don't limit pkg-config generation

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(bmxtimecode PRIVATE
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(bmxtimecode "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
-install(TARGETS bmxtimecode DESTINATION bin)
+install(TARGETS bmxtimecode DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/apps/bmxparse/CMakeLists.txt
+++ b/apps/bmxparse/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(bmxparse PRIVATE
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(bmxparse "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
-install(TARGETS bmxparse DESTINATION bin)
+install(TARGETS bmxparse DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/apps/bmxtranswrap/CMakeLists.txt
+++ b/apps/bmxtranswrap/CMakeLists.txt
@@ -17,4 +17,4 @@ target_link_libraries(bmxtranswrap PRIVATE
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(bmxtranswrap "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
-install(TARGETS bmxtranswrap DESTINATION bin)
+install(TARGETS bmxtranswrap DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/apps/mxf2raw/CMakeLists.txt
+++ b/apps/mxf2raw/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(mxf2raw PRIVATE
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(mxf2raw "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
-install(TARGETS mxf2raw DESTINATION bin)
+install(TARGETS mxf2raw DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/apps/raw2bmx/CMakeLists.txt
+++ b/apps/raw2bmx/CMakeLists.txt
@@ -17,4 +17,4 @@ target_link_libraries(raw2bmx PRIVATE
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(raw2bmx "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
-install(TARGETS raw2bmx DESTINATION bin)
+install(TARGETS raw2bmx DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bmx.pc.in
+++ b/bmx.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@

--- a/deps/libMXFpp/CMakeLists.txt
+++ b/deps/libMXFpp/CMakeLists.txt
@@ -19,6 +19,7 @@ project(libMXF++
     LANGUAGES CXX
 )
 
+include(GNUInstallDirs) # provides access to ${CMAKE_INSTALL_BINDIR} etc.
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/options.cmake")
 
 if(MSVC AND CMP0091_value STREQUAL NEW)

--- a/deps/libMXFpp/examples/Common/CMakeLists.txt
+++ b/deps/libMXFpp/examples/Common/CMakeLists.txt
@@ -27,4 +27,4 @@ target_link_libraries(libmxfpp_examples_common PUBLIC
 include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(libmxfpp_examples_common "${CMAKE_CURRENT_LIST_DIR}" "libMXF++")
 
-install(FILES ${libmxfpp_examples_common_headers} DESTINATION include/libMXF++/examples/Common)
+install(FILES ${libmxfpp_examples_common_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libMXF++/examples/Common)

--- a/deps/libMXFpp/examples/D10MXFOP1AWriter/CMakeLists.txt
+++ b/deps/libMXFpp/examples/D10MXFOP1AWriter/CMakeLists.txt
@@ -30,10 +30,10 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(d10mxfop1awriter "${CMAKE_CURRENT_LIST_DIR}" "libMXF++")
 
 install(TARGETS d10mxfop1awriter
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(FILES ${d10mxfop1awriter_headers} DESTINATION include/libMXF++/examples/D10MXFOP1AWriter)
+install(FILES ${d10mxfop1awriter_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libMXF++/examples/D10MXFOP1AWriter)
 
 
 add_executable(test_d10mxfop1awriter

--- a/deps/libMXFpp/examples/OPAtomReader/CMakeLists.txt
+++ b/deps/libMXFpp/examples/OPAtomReader/CMakeLists.txt
@@ -42,10 +42,10 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(opatomreader "${CMAKE_CURRENT_LIST_DIR}" "libMXF++")
 
 install(TARGETS opatomreader
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(FILES ${opatomreader_headers} DESTINATION include/libMXF++/examples/OPAtomReader)
+install(FILES ${opatomreader_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libMXF++/examples/OPAtomReader)
 
 
 add_executable(test_opatomreader

--- a/deps/libMXFpp/libMXF++.pc.in
+++ b/deps/libMXFpp/libMXF++.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@

--- a/deps/libMXFpp/libMXF++/CMakeLists.txt
+++ b/deps/libMXFpp/libMXF++/CMakeLists.txt
@@ -83,15 +83,13 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(MXFpp "${CMAKE_CURRENT_LIST_DIR}" "libMXF++")
 
 install(TARGETS MXFpp
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 foreach(include_file ${MXFpp_headers})
     get_filename_component(dir ${include_file} DIRECTORY)
-    install(FILES ${include_file} DESTINATION include/libMXF++/${dir})
+    install(FILES ${include_file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libMXF++/${dir})
 endforeach()
 
-if(UNIX)
-    configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION lib/pkgconfig)
-endif()
+configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,5 +2,5 @@ add_subdirectory(bmx)
 
 foreach(include_file ${bmx_headers})
     get_filename_component(dir ${include_file} DIRECTORY)
-    install(FILES ${include_file} DESTINATION "include/${dir}")
+    install(FILES ${include_file} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${dir}")
 endforeach()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,12 +92,10 @@ include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
 set_source_filename(bmx "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
 install(TARGETS bmx
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 # headers are installed in the include/CMakeLists.txt
 
-if(UNIX)
-    configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION lib/pkgconfig)
-endif()
+configure_file(../${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,5 +16,5 @@ foreach(tool_source ${tool_sources})
     include("${PROJECT_SOURCE_DIR}/cmake/source_filename.cmake")
     set_source_filename(${tool_target} "${CMAKE_CURRENT_LIST_DIR}" "bmx")
 
-    install(TARGETS ${tool_target} DESTINATION bin)
+    install(TARGETS ${tool_target} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach()


### PR DESCRIPTION
Apply the changes contributed in https://github.com/bbc/bmx/pull/47 for libMXF to libMXF++ and bmx.