### PR TITLE
Allow parser ParseFrameSize to return > available data

### DIFF
--- a/include/bmx/ByteBuffer.h
+++ b/include/bmx/ByteBuffer.h
@@ -43,7 +43,16 @@ namespace bmx
 
 
 class InsufficientBytes : public std::exception
-{};
+{
+public:
+    InsufficientBytes();
+    InsufficientBytes(uint32_t required_size);
+
+    uint32_t GetRequiredSize() const { return mRequiredSize; }
+
+private:
+    uint32_t mRequiredSize;
+};
 
 
 class ByteBuffer

--- a/src/common/ByteBuffer.cpp
+++ b/src/common/ByteBuffer.cpp
@@ -39,6 +39,19 @@ using namespace std;
 using namespace bmx;
 
 
+InsufficientBytes::InsufficientBytes()
+: exception()
+{
+    mRequiredSize = 0;
+}
+
+InsufficientBytes::InsufficientBytes(uint32_t required_size)
+: exception()
+{
+    mRequiredSize = required_size;
+}
+
+
 ByteBuffer::ByteBuffer(const unsigned char *data, uint32_t size, bool big_endian)
 {
     mData = data;

--- a/src/essence_parser/DVEssenceParser.cpp
+++ b/src/essence_parser/DVEssenceParser.cpp
@@ -100,11 +100,7 @@ uint32_t DVEssenceParser::ParseFrameSize(const unsigned char *data, uint32_t dat
         return ESSENCE_PARSER_NULL_FRAME_SIZE;
     }
 
-    uint32_t frame_size = ParseFrameSizeInt(data, data_size);
-    if (data_size < frame_size)
-        return ESSENCE_PARSER_NULL_OFFSET;
-
-    return frame_size;
+    return ParseFrameSizeInt(data, data_size);
 }
 
 void DVEssenceParser::ParseFrameInfo(const unsigned char *data, uint32_t data_size)

--- a/src/essence_parser/JXSEssenceParser.cpp
+++ b/src/essence_parser/JXSEssenceParser.cpp
@@ -125,9 +125,12 @@ uint32_t JXSEssenceParser::ParseFrameSize(const unsigned char *data, uint32_t da
         ParseFrameInfo(data, data_size);
         return mFrameSize;
     }
-    catch (const InsufficientBytes&)
+    catch (const InsufficientBytes &ex)
     {
-        return ESSENCE_PARSER_NULL_OFFSET;
+        if (ex.GetRequiredSize() > 0)
+            return ex.GetRequiredSize();
+        else
+            return ESSENCE_PARSER_NULL_OFFSET;
     }
     catch (const InvalidData&)
     {
@@ -204,7 +207,7 @@ void JXSEssenceParser::ParseFrameInfo(const unsigned char *data, uint32_t data_s
                 // size of the bitstream
                 size = PIH_.LcodSize();
                 if (size > data_size)
-                    throw InsufficientBytes();
+                    throw InsufficientBytes(size);
                 mFrameSize = size;
                 // Profile and level
                 m_subDesc.JPEGXSPpih = PIH_.Ppih(); // profile

--- a/src/essence_parser/RDD36EssenceParser.cpp
+++ b/src/essence_parser/RDD36EssenceParser.cpp
@@ -150,8 +150,6 @@ uint32_t RDD36EssenceParser::ParseFrameSize(const unsigned char *data, uint32_t 
     uint32_t frame_identifier = buffer.GetF32(32);
     if (frame_identifier != RDD36_FRAME_ID)
         return ESSENCE_PARSER_NULL_FRAME_SIZE;
-    else if (data_size < frame_size)
-        return ESSENCE_PARSER_NULL_OFFSET;
     else
         return frame_size;
 }

--- a/src/essence_parser/RawEssenceReader.cpp
+++ b/src/essence_parser/RawEssenceReader.cpp
@@ -210,6 +210,18 @@ bool RawEssenceReader::ReadAndParseSample()
         sample_num_read += num_read;
     }
 
+    // Read remaining bytes if sample_size is larger
+    if (sample_size != ESSENCE_PARSER_NULL_FRAME_SIZE &&
+            sample_size != ESSENCE_PARSER_NULL_OFFSET &&
+            sample_size > sample_num_read)
+    {
+        sample_num_read += ReadBytes(sample_size - sample_num_read);
+        if (sample_size > sample_num_read) {
+            log_warn("Failed to read last remaining bytes %u in frame\n", sample_size - sample_num_read);
+            sample_size = ESSENCE_PARSER_NULL_OFFSET;
+        }
+    }
+
     if (sample_size == ESSENCE_PARSER_NULL_FRAME_SIZE) {
         // invalid or null sample data
         mLastSampleRead = true;

--- a/src/essence_parser/VC3EssenceParser.cpp
+++ b/src/essence_parser/VC3EssenceParser.cpp
@@ -154,12 +154,8 @@ uint32_t VC3EssenceParser::ParseFrameSize(const unsigned char *data, uint32_t da
     size_t i;
     for (i = 0; i < BMX_ARRAY_SIZE(COMPRESSION_PARAMETERS); i++)
     {
-        if (compression_id == COMPRESSION_PARAMETERS[i].compression_id) {
-            if (data_size >= COMPRESSION_PARAMETERS[i].frame_size)
-                return COMPRESSION_PARAMETERS[i].frame_size;
-            else
-                return ESSENCE_PARSER_NULL_OFFSET;
-        }
+        if (compression_id == COMPRESSION_PARAMETERS[i].compression_id)
+            return COMPRESSION_PARAMETERS[i].frame_size;
     }
 
     return ESSENCE_PARSER_NULL_FRAME_SIZE;


### PR DESCRIPTION
This can speed up essence parsing for DV, RDD 36 (ProRes), JPEG XS and VC3.

Users of `ParseFrameSize` (in bmxparse and RawEssenceReader) need to check and read the remainder.

This is a breaking change for users of EssenceParser derived classes in bmx.