### PR TITLE
Reader tolerates number != 01 in Timed Text essence key

### DIFF
--- a/deps/libMXF/mxf/mxf_labels_and_keys.c
+++ b/deps/libMXF/mxf/mxf_labels_and_keys.c
@@ -247,6 +247,13 @@ void mxf_complete_essence_element_key(mxfKey *key, uint8_t count, uint8_t type, 
     key->octet15 = num;
 }
 
+void mxf_complete_essence_element_key_from_track_num(mxfKey *key, uint32_t track_num)
+{
+    key->octet13 = (uint8_t)((track_num >> 16) & 0xff);
+    key->octet14 = (uint8_t)((track_num >> 8) & 0xff);
+    key->octet15 = (uint8_t)(track_num & 0xff);
+}
+
 void mxf_complete_essence_element_track_num(uint32_t *trackNum, uint8_t count, uint8_t type, uint8_t num)
 {
     *trackNum &= 0xFF000000;

--- a/deps/libMXF/mxf/mxf_labels_and_keys.h
+++ b/deps/libMXF/mxf/mxf_labels_and_keys.h
@@ -777,6 +777,7 @@ static const mxfUL ADM_ITU2076_PROFILES_LEVELS =
 
 
 void mxf_complete_essence_element_key(mxfKey *key, uint8_t count, uint8_t type, uint8_t num);
+void mxf_complete_essence_element_key_from_track_num(mxfKey *key, uint32_t track_num);
 void mxf_complete_essence_element_track_num(uint32_t *trackNum, uint8_t count, uint8_t type, uint8_t num);
 
 

--- a/include/bmx/mxf_reader/MXFTimedTextTrackReader.h
+++ b/include/bmx/mxf_reader/MXFTimedTextTrackReader.h
@@ -74,6 +74,7 @@ private:
 
 private:
     uint32_t mBodySID;
+    mxfKey mEssenceElementKey;
 };
 
 

--- a/src/mxf_reader/MXFTimedTextTrackReader.cpp
+++ b/src/mxf_reader/MXFTimedTextTrackReader.cpp
@@ -54,6 +54,9 @@ MXFTimedTextTrackReader::MXFTimedTextTrackReader(MXFFileReader *file_reader, siz
 {
     BMX_ASSERT(track_info->essence_type == TIMED_TEXT);
     mBodySID = 0;
+
+    mEssenceElementKey = MXF_EE_K(TimedText);
+    mxf_complete_essence_element_key_from_track_num(&mEssenceElementKey, track_info->file_track_number);
 }
 
 MXFTimedTextTrackReader::~MXFTimedTextTrackReader()
@@ -110,7 +113,7 @@ void MXFTimedTextTrackReader::ReadTimedText(FILE *file_out, unsigned char **data
 {
     BMX_ASSERT(mBodySID != 0);
 
-    ReadStream(mBodySID, &MXF_EE_K(TimedText), file_out, data_out, size_out, 0);
+    ReadStream(mBodySID, &mEssenceElementKey, file_out, data_out, size_out, 0);
 }
 
 void MXFTimedTextTrackReader::ReadAncillaryResourceById(mxfUUID resource_id, FILE *file_out,
@@ -147,7 +150,7 @@ TimedTextMXFResourceProvider* MXFTimedTextTrackReader::CreateResourceProvider()
         provider = new TimedTextMXFResourceProvider(file);
 
         vector<pair<int64_t, int64_t> > ranges;
-        ReadStream(mBodySID, &MXF_EE_K(TimedText), 0, 0, 0, &ranges);
+        ReadStream(mBodySID, &mEssenceElementKey, 0, 0, 0, &ranges);
         provider->AddTimedTextResource(ranges);
 
         vector<TimedTextAncillaryResource> &anc_resources = GetManifest()->GetAncillaryResources();


### PR DESCRIPTION
ST 429-5 normatively requires the Essence Element Number byte in the essence element key (and Track Number) to be 01h. However, it's only used to link tracks to essence elements and so readers should be tolerant of writers using 00h for example.