### PR TITLE
Include item or set key in low-level read error messages

### DIFF
--- a/deps/libMXF/mxf/mxf_avid.c
+++ b/deps/libMXF/mxf/mxf_avid.c
@@ -377,7 +377,7 @@ static int get_indirect_string(MXFMetadataSet *set, const mxfKey *itemKey, mxfUT
     uint8_t *itemValuePtr;
     uint16_t strSize;
 
-    CHK_OFAIL(mxf_get_item(set, itemKey, &item));
+    CHK_OFAIL_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     /* initial check */
     if (item->length <= sizeof(prefix_BE) ||
@@ -447,7 +447,7 @@ static int get_indirect_int32(MXFMetadataSet *set, const mxfKey *itemKey, int32_
     int isBigEndian;
     MXFMetadataItem *item;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     /* initial check */
     if (item->length <= sizeof(prefix_BE) ||
@@ -840,7 +840,7 @@ int mxf_avid_get_rgb_color_item(MXFMetadataSet *set, const mxfKey *itemKey, RGBC
 {
     MXFMetadataItem *item;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length == 3 * 2);
 
     mxf_get_uint16(item->value, &value->red);
@@ -1112,7 +1112,7 @@ int mxf_avid_get_product_version_item(MXFMetadataSet *set, const mxfKey *itemKey
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length == mxfProductVersion_extlen - 1);
 
     mxf_avid_get_product_version(item->value, value);

--- a/deps/libMXF/mxf/mxf_avid_metadictionary.c
+++ b/deps/libMXF/mxf/mxf_avid_metadictionary.c
@@ -166,7 +166,7 @@ static int append_name_to_string_array(MXFMetadataSet *set, const mxfKey *itemKe
 
     if (mxf_have_item(set, itemKey))
     {
-        CHK_ORET(mxf_get_item(set, itemKey, &namesItem));
+        CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &namesItem));
         existingNameArraySize = namesItem->length;
     }
     nameArraySize = mxf_get_external_utf16string_size(name);
@@ -446,7 +446,7 @@ int mxf_avid_create_classdef(AvidMetaDictionary *metaDict, const mxfUL *id, cons
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(ClassDefinition, ParentClass), parentId));
     CHK_ORET(mxf_set_boolean_item(newSet, &MXF_ITEM_K(ClassDefinition, IsConcrete), isConcrete));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(ClassDefinition, ParentClass), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(ClassDefinition, ParentClass), mxf_get_item(newSet, &MXF_ITEM_K(ClassDefinition, ParentClass), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->classWeakRefList, item, -1, parentId));
     CHK_ORET(add_metadef_to_list(&metaDict->classMetaDefList, id, &newSet->instanceUID));
 
@@ -513,7 +513,7 @@ int mxf_avid_create_typedef_enum(AvidMetaDictionary *metaDict, const mxfUL *id, 
 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionEnumeration, Type), typeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionEnumeration, Type), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionEnumeration, Type), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionEnumeration, Type), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, -1, typeId));
 
     *typeDefSet = newSet;
@@ -569,7 +569,7 @@ int mxf_avid_create_typedef_fixedarray(AvidMetaDictionary *metaDict, const mxfUL
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionFixedArray, ElementType), elementTypeId));
     CHK_ORET(mxf_set_uint32_item(newSet, &MXF_ITEM_K(TypeDefinitionFixedArray, ElementCount), elementCount));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionFixedArray, ElementType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionFixedArray, ElementType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionFixedArray, ElementType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, -1, elementTypeId));
 
     *typeDefSet = newSet;
@@ -629,7 +629,7 @@ int mxf_avid_add_typedef_record_member(AvidMetaDictionary *metaDict, MXFMetadata
 
     CHK_ORET(mxf_get_array_item_count(typeDefSet, &MXF_ITEM_K(TypeDefinitionRecord, MemberTypes), &memberCount));
 
-    CHK_ORET(mxf_get_item(typeDefSet, &MXF_ITEM_K(TypeDefinitionRecord, MemberTypes), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionRecord, MemberTypes), mxf_get_item(typeDefSet, &MXF_ITEM_K(TypeDefinitionRecord, MemberTypes), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, memberCount - 1, typeId));
 
     return 1;
@@ -646,7 +646,7 @@ int mxf_avid_create_typedef_rename(AvidMetaDictionary *metaDict, const mxfUL *id
 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionRename, RenamedType), renamedTypeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionRename, RenamedType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionRename, RenamedType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionRename, RenamedType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, -1, renamedTypeId));
 
     *typeDefSet = newSet;
@@ -664,7 +664,7 @@ int mxf_avid_create_typedef_set(AvidMetaDictionary *metaDict, const mxfUL *id, c
 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionSet, ElementType), elementTypeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionSet, ElementType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionSet, ElementType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionSet, ElementType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, -1, elementTypeId));
 
     *typeDefSet = newSet;
@@ -688,7 +688,7 @@ int mxf_avid_create_typedef_string(AvidMetaDictionary *metaDict, const mxfUL *id
 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionString, ElementType), elementTypeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionString, ElementType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionString, ElementType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionString, ElementType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, -1, elementTypeId));
 
     *typeDefSet = newSet;
@@ -708,7 +708,7 @@ int mxf_avid_create_typedef_strongref(AvidMetaDictionary *metaDict, const mxfUL 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionStrongObjectReference, ReferencedType),
                              referencedTypeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionStrongObjectReference, ReferencedType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionStrongObjectReference, ReferencedType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionStrongObjectReference, ReferencedType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->classWeakRefList, item, -1, referencedTypeId));
 
     *typeDefSet = newSet;
@@ -726,7 +726,7 @@ int mxf_avid_create_typedef_vararray(AvidMetaDictionary *metaDict, const mxfUL *
 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionVariableArray, ElementType), elementTypeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionVariableArray, ElementType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionVariableArray, ElementType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionVariableArray, ElementType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->typeWeakRefList, item, -1, elementTypeId));
 
     *typeDefSet = newSet;
@@ -745,7 +745,7 @@ int mxf_avid_create_typedef_weakref(AvidMetaDictionary *metaDict, const mxfUL *i
 
     CHK_ORET(mxf_set_ul_item(newSet, &MXF_ITEM_K(TypeDefinitionWeakObjectReference, ReferencedType), referencedTypeId));
 
-    CHK_ORET(mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionWeakObjectReference, ReferencedType), &item));
+    CHK_ORET_GET_ITEM(&MXF_ITEM_K(TypeDefinitionWeakObjectReference, ReferencedType), mxf_get_item(newSet, &MXF_ITEM_K(TypeDefinitionWeakObjectReference, ReferencedType), &item));
     CHK_ORET(add_weakref_to_list(&metaDict->classWeakRefList, item, -1, referencedTypeId));
 
     *typeDefSet = newSet;

--- a/deps/libMXF/mxf/mxf_header_metadata.c
+++ b/deps/libMXF/mxf/mxf_header_metadata.c
@@ -45,7 +45,6 @@
 #include <mxf/mxf_macros.h>
 
 
-
 static void free_metadata_item_value(MXFMetadataItem *item)
 {
     SAFE_FREE(item->value);
@@ -170,7 +169,7 @@ static int validate_set(MXFMetadataSet *set, MXFSetDef *setDef, int logErrors)
 
         if (mxf_have_item(set, &itemDef->key))
         {
-            CHK_ORET(mxf_get_item(set, &itemDef->key, &item));
+            CHK_ORET_GET_ITEM(&itemDef->key, mxf_get_item(set, &itemDef->key, &item));
 
 
 #define CHECK_LENGTH(len) \
@@ -809,7 +808,7 @@ int mxf_read_filtered_header_metadata(MXFFile *mxfFile, MXFReadFilter *filter,
 
                 if (!skip)
                 {
-                    CHK_ORET((result = mxf_read_and_return_set(mxfFile, &key, len, headerMetadata, 0, &newSet)) > 0);
+                    CHK_ORET_READ_SET(&key, (result = mxf_read_and_return_set(mxfFile, &key, len, headerMetadata, 0, &newSet)) > 0);
 
                     if (result == 1) /* set was read and returned in "set" parameter */
                     {
@@ -837,7 +836,7 @@ int mxf_read_filtered_header_metadata(MXFFile *mxfFile, MXFReadFilter *filter,
             }
             else
             {
-                CHK_ORET(mxf_read_set(mxfFile, &key, len, headerMetadata, 1) > 0);
+                CHK_ORET_READ_SET(&key, mxf_read_set(mxfFile, &key, len, headerMetadata, 1) > 0);
             }
         }
         count += len;
@@ -1860,7 +1859,7 @@ int mxf_clone_item(MXFMetadataSet *sourceSet, const mxfKey *itemKey, MXFMetadata
 
     assert(destSet->headerMetadata != NULL);
 
-    CHK_ORET(mxf_get_item(sourceSet, itemKey, &sourceItem));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(sourceSet, itemKey, &sourceItem));
     CHK_ORET(get_or_create_set_item(destSet->headerMetadata, destSet, itemKey, &newItem));
     CHK_ORET(mxf_set_item_value(newItem, sourceItem->value, sourceItem->length));
 
@@ -2254,7 +2253,7 @@ int mxf_get_item_len(MXFMetadataSet *set, const mxfKey *itemKey, uint16_t *len)
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     *len = item->length;
     return 1;
@@ -2264,7 +2263,7 @@ int mxf_get_item_len(MXFMetadataSet *set, const mxfKey *itemKey, uint16_t *len)
 #define GET_VALUE(len, get_func) \
     MXFMetadataItem *item = NULL; \
     \
-    CHK_ORET(mxf_get_item(set, itemKey, &item)); \
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item)); \
     CHK_ORET(item->length == len); \
     \
     get_func(item->value, value); \
@@ -2346,7 +2345,7 @@ int mxf_get_utf16string_item_size(MXFMetadataSet *set, const mxfKey *itemKey, ui
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     *size = mxf_get_utf16string_size(item->value, item->length);
 
@@ -2358,7 +2357,7 @@ int mxf_get_utf16string_item(MXFMetadataSet *set, const mxfKey *itemKey, mxfUTF1
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     mxf_get_utf16string(item->value, item->length, value);
 
@@ -2370,7 +2369,7 @@ int mxf_get_utf8string_item_size(MXFMetadataSet *set, const mxfKey *itemKey, uin
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     *size = mxf_get_utf8string_size(item->value, item->length);
 
@@ -2382,7 +2381,7 @@ int mxf_get_utf8string_item(MXFMetadataSet *set, const mxfKey *itemKey, char *va
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     mxf_get_utf8string(item->value, item->length, value);
 
@@ -2394,7 +2393,7 @@ int mxf_get_iso7string_item_size(MXFMetadataSet *set, const mxfKey *itemKey, uin
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     *size = mxf_get_iso7string_size(item->value, item->length);
 
@@ -2406,7 +2405,7 @@ int mxf_get_iso7string_item(MXFMetadataSet *set, const mxfKey *itemKey, char *va
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
 
     mxf_get_iso7string(item->value, item->length, value);
 
@@ -2519,7 +2518,7 @@ int mxf_get_j2k_ext_capabilities_item(MXFMetadataSet *set, const mxfKey *itemKey
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(mxf_get_j2k_ext_capabilities(item->value, item->length, value));
 
     return 1;
@@ -2539,7 +2538,7 @@ int mxf_get_video_line_map_item(MXFMetadataSet *set, const mxfKey *itemKey, mxfV
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length == 16);
 
     mxf_get_int32(&item->value[8], &value->first);
@@ -2558,7 +2557,7 @@ int mxf_get_array_item_count(MXFMetadataSet *set, const mxfKey *itemKey, uint32_
     MXFMetadataItem *item = NULL;
     uint32_t elementLength;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length >= 8);
 
     mxf_get_array_header(item->value, count, &elementLength);
@@ -2571,7 +2570,7 @@ int mxf_get_array_item_element_len(MXFMetadataSet *set, const mxfKey *itemKey, u
     MXFMetadataItem *item = NULL;
     uint32_t count;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length >= 8);
 
     mxf_get_array_header(item->value, &count, elementLen);
@@ -2585,7 +2584,7 @@ int mxf_get_array_item_element(MXFMetadataSet *set, const mxfKey *itemKey, uint3
     uint32_t elementLen;
     uint32_t count;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length >= 8);
 
     mxf_get_array_header(item->value, &count, &elementLen);
@@ -2601,7 +2600,7 @@ int mxf_initialise_array_item_iterator(MXFMetadataSet *set, const mxfKey *itemKe
 {
     MXFMetadataItem *item = NULL;
 
-    CHK_ORET(mxf_get_item(set, itemKey, &item));
+    CHK_ORET_GET_ITEM(itemKey, mxf_get_item(set, itemKey, &item));
     CHK_ORET(item->length >= 8);
 
     arrayIter->item = item;

--- a/deps/libMXF/mxf/mxf_header_metadata.h
+++ b/deps/libMXF/mxf/mxf_header_metadata.h
@@ -41,6 +41,52 @@ extern "C"
 #endif
 
 
+#define CHK_ORET_GET_ITEM(key, cmd)                                     \
+    do {                                                                \
+        if (!(cmd)) {                                                   \
+            char key_str[KEY_STR_SIZE];                                 \
+            mxf_sprint_key(key_str, key);                               \
+            mxf_log_error("'%s' for item key '%s' failed, in %s:%d\n",  \
+                          #cmd, key_str, __FILENAME__, __LINE__);       \
+            return 0;                                                   \
+        }                                                               \
+    } while (0)
+
+#define CHK_OFAIL_GET_ITEM(key, cmd)                                    \
+    do {                                                                \
+        if (!(cmd)) {                                                   \
+            char key_str[KEY_STR_SIZE];                                 \
+            mxf_sprint_key(key_str, key);                               \
+            mxf_log_error("'%s' for item key '%s' failed, in %s:%d\n",  \
+                          #cmd, key_str, __FILENAME__, __LINE__);       \
+            goto fail;                                                  \
+        }                                                               \
+    } while (0)
+
+#define CHK_ORET_READ_SET(key, cmd)                                     \
+    do {                                                                \
+        if (!(cmd)) {                                                   \
+            char key_str[KEY_STR_SIZE];                                 \
+            mxf_sprint_key(key_str, key);                               \
+            mxf_log_error("'%s' for set key '%s' failed, in %s:%d\n",   \
+                          #cmd, key_str, __FILENAME__, __LINE__);       \
+            return 0;                                                   \
+        }                                                               \
+    } while (0)
+
+#define CHK_OFAIL_READ_SET(key, cmd)                                    \
+    do {                                                                \
+        if (!(cmd)) {                                                   \
+            char key_str[KEY_STR_SIZE];                                 \
+            mxf_sprint_key(key_str, key);                               \
+            mxf_log_error("'%s' for set key '%s' failed, in %s:%d\n",   \
+                          #cmd, key_str, __FILENAME__, __LINE__);       \
+            goto fail;                                                  \
+        }                                                               \
+    } while (0)
+
+
+
 typedef struct
 {
     mxfKey key;

--- a/deps/libMXFpp/libMXF++/MetadataSet.cpp
+++ b/deps/libMXFpp/libMXF++/MetadataSet.cpp
@@ -43,6 +43,19 @@ using namespace std;
 using namespace mxfpp;
 
 
+#define MXFPP_CHECK_GET_ITEM(key, cmd)                                                  \
+    do {                                                                                \
+        if (!(cmd)) {                                                                   \
+            char key_str[KEY_STR_SIZE];                                                 \
+            mxf_sprint_key(key_str, key);                                               \
+            mxf_log_error("'%s' for item key '%s' failed, at %s:%d\n",                  \
+                          #cmd, key_str, __FILENAME__, __LINE__);                       \
+            throw MXFException("'%s' for item key '%s' failed, at %s:%d",               \
+                               #cmd, __FILENAME__, __LINE__);                           \
+        }                                                                               \
+    } while (0)
+
+
 
 class ReferencedObjectIterator : public ObjectIterator
 {
@@ -154,7 +167,7 @@ ByteArray MetadataSet::getRawBytesItem(const mxfKey *itemKey) const
 {
     MXFMetadataItem *item;
     ByteArray byteArray;
-    MXFPP_CHECK(mxf_get_item(_cMetadataSet, itemKey, &item));
+    MXFPP_CHECK_GET_ITEM(itemKey, mxf_get_item(_cMetadataSet, itemKey, &item));
     byteArray.data = item->value;
     byteArray.length = item->length;
     return byteArray;
@@ -290,7 +303,7 @@ mxfProductVersion MetadataSet::getProductVersionItem(const mxfKey *itemKey) cons
 {
     mxfProductVersion result;
     MXFMetadataItem *item;
-    MXFPP_CHECK(mxf_get_item(_cMetadataSet, itemKey, &item));
+    MXFPP_CHECK_GET_ITEM(itemKey, mxf_get_item(_cMetadataSet, itemKey, &item));
     if (item->length == mxfProductVersion_extlen - 1)
     {
         mxf_avid_get_product_version(item->value, &result);


### PR DESCRIPTION
Provides the item key in the error message stating the item could not be read or the set key if that could not be read. This makes it easier to figure out what was missing / invalid in the file.