### PR TITLE
Fix the command line option for ProRes 4444 XQ

### DIFF
--- a/apps/raw2bmx/raw2bmx.cpp
+++ b/apps/raw2bmx/raw2bmx.cpp
@@ -3748,7 +3748,10 @@ int main(int argc, const char** argv)
             inputs.push_back(input);
             cmdln_index++;
         }
-        else if (strcmp(argv[cmdln_index], "--rdd36_4444_hq") == 0)
+        // Allowing --rdd36_4444_xq as defined in the cli help as well as --rdd36_4444_hq
+        // which was defined first to keep backwards compatibility with older scripts.
+        else if (strcmp(argv[cmdln_index], "--rdd36_4444_xq") == 0 ||
+                 strcmp(argv[cmdln_index], "--rdd36_4444_hq") == 0)
         {
             if (cmdln_index + 1 >= argc)
             {


### PR DESCRIPTION
Hello,

I just played around with raw2bmx and found that there is a bug/discrepancy between the command line description and the actual parser. For ProRes 4444 XQ, the description says to use `--rdd36_4444_xq` while the actual parser expected `--rdd36_4444_hq`. 

Cheers,
Ingmar