### PR TITLE
Add a compatibility fix for C++20

### DIFF
--- a/deps/libMXFpp/libMXF++/MXFVersion.cpp
+++ b/deps/libMXFpp/libMXF++/MXFVersion.cpp
@@ -33,6 +33,8 @@
 #include "config.h"
 #endif
 
+#include <string>
+
 #include "git.h"
 #include "fallback_git_version.h"
 

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -219,7 +219,7 @@ mxfProductVersion bmx::get_bmx_mxf_product_version()
         // Set the patch version value to the commit offset from the release tag.
         // The commit offset is part of the git describe tag string which has the
         // format "<tag>-<offset>-g<commit id>"
-        string describe = bmx_git::DescribeTag();
+        string describe = std::string(bmx_git::DescribeTag());
 #ifdef PACKAGE_GIT_VERSION_STRING
         if (describe.empty() || describe == "unknown")
             describe = PACKAGE_GIT_VERSION_STRING;


### PR DESCRIPTION
Add a compatibility fix for C++20 (and maybe others) to fix a non-supported conversion from std::string_view to std::string.

When preparing a recipe for the Conan package manager to properly add bmx as a dependency in other projects. One of the points there is to honor the user request for the C++ version requested by the user, thus I patch out the fixed setting of C++11. (See corresponding PR: https://github.com/conan-io/conan-center-index/pull/23955)

With C++20 set, I got the following error requiring an implicit conversion:
```
/home/ingmar/.conan2/p/b/bmx8699e87e1c8ea/b/src/src/common/Version.cpp: In function ‘mxfProductVersion bmx::get_bmx_mxf_product_version()’:
/home/ingmar/.conan2/p/b/bmx8699e87e1c8ea/b/src/src/common/Version.cpp:222:47: error: conversion from ‘const bmx_git::StringOrView’ {aka ‘const std::basic_string_view<char>’} to non-scalar type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} requested
  222 |         string describe = bmx_git::DescribeTag();
``` 