### PR TITLE
Remove the fixed -O2 compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(MSVC)
         endforeach()
     endif()
 else()
-    add_compile_options(-W -Wall -O2)
+    add_compile_options(-Wextra -Wall)
 
     # Enable large file support on 32-bit systems.
     add_definitions(

--- a/deps/libMXF/CMakeLists.txt
+++ b/deps/libMXF/CMakeLists.txt
@@ -74,7 +74,7 @@ if(MSVC)
         endforeach()
     endif()
 else()
-    add_compile_options(-W -Wall -O2)
+    add_compile_options(-Wextra -Wall)
 
     # Enable large file support on 32-bit systems.
     add_definitions(

--- a/deps/libMXF/mxf/mxf_memory_file.c
+++ b/deps/libMXF/mxf/mxf_memory_file.c
@@ -202,8 +202,8 @@ static uint32_t mem_file_read(MXFFileSysData *sysData, uint8_t *data, uint32_t c
 static uint32_t mem_file_write(MXFFileSysData *sysData, const uint8_t *data, uint32_t count)
 {
     uint32_t totalWrite = 0;
-    size_t posChunkIndex;
-    int64_t posChunkPos;
+    size_t posChunkIndex = 0;
+    int64_t posChunkPos = 0;
     int64_t numWrite;
     int64_t fileSize;
 
@@ -220,7 +220,7 @@ static uint32_t mem_file_write(MXFFileSysData *sysData, const uint8_t *data, uin
 
         /* add data from fileSize to sysData->position */
         if (sysData->position > fileSize) {
-            size_t endPosChunkIndex;
+            size_t endPosChunkIndex = 0;
             int64_t endPosChunkPos;
             int64_t chunkRemainder;
             int64_t originalPos = sysData->position;

--- a/deps/libMXFpp/CMakeLists.txt
+++ b/deps/libMXFpp/CMakeLists.txt
@@ -59,7 +59,7 @@ if(MSVC)
         endforeach()
     endif()
 else()
-    add_compile_options(-W -Wall -O2)
+    add_compile_options(-Wextra -Wall)
 
     # Enable large file support on 32-bit systems.
     add_definitions(


### PR DESCRIPTION
By default it is better to rely on CMake setting the optimization based on the build type. Release for example even uses `-O3`. There is a more elaborate description in the top answer on https://stackoverflow.com/questions/48754619/what-are-cmake-build-type-debug-release-relwithdebinfo-and-minsizerel

With that change, a build system like conan allows the user to pass individual optimization flags if needed without overriding those.

I'm not sure if it is good practice to do that, but in a project of mine I used the following snippet before I changed fully to conan where the conan profile/settings define the cmake build type. Maybe to ensure to by default build an optimized release version, something like that makes sense:
```
if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE Release)
endif()
```

Additionally to my knowledge `-W` and `-Wextra` should be basically the same, while `-Wextra` is a bit more clear. However despite my knowledge, there where a few small warnings popping up regarding uninitialized variable in one file due to the initialization happening in a helper function which gets passed the pointers. So I initialized the 3 variables.