### PR TITLE
build: Treat implicit function declarations in C as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(MSVC)
         endforeach()
     endif()
 else()
-    add_compile_options(-Wextra -Wall)
+    add_compile_options(-Wextra -Wall $<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
 
     # Enable large file support on 32-bit systems.
     add_definitions(

--- a/deps/libMXF/CMakeLists.txt
+++ b/deps/libMXF/CMakeLists.txt
@@ -74,7 +74,7 @@ if(MSVC)
         endforeach()
     endif()
 else()
-    add_compile_options(-Wextra -Wall)
+    add_compile_options(-Wextra -Wall $<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
 
     # Enable large file support on 32-bit systems.
     add_definitions(

--- a/deps/libMXFpp/CMakeLists.txt
+++ b/deps/libMXFpp/CMakeLists.txt
@@ -59,7 +59,7 @@ if(MSVC)
         endforeach()
     endif()
 else()
-    add_compile_options(-Wextra -Wall)
+    add_compile_options(-Wextra -Wall $<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
 
     # Enable large file support on 32-bit systems.
     add_definitions(


### PR DESCRIPTION
Building with CFLAGS="-std=c11" using GCC exposed that certain function extensions to the C standard could have their pointer return values truncated.

E.g. the POSIX strdup extension was unknown to gcc when using "-std=c11". GCC assumed it would be a function that returned an "int". That would then fail if the string pointer required > 32 bits.

C99 removed support for implicit functions declarations. Some compilers, e.g. like gcc, will only warn about it. Clang has changed it to an error in version 16.

strdup for example has been added to C23.

Workaround for #77