### PR TITLE
Proposal for hinting to Conan availability of bmx in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ Source distributions, including dependencies, and binaries are made available in
 
 Source and binary distributions are generally only created when a new feature is required for creating standard compliant sample files for example, or when a release hasn't been made for a long time.
 
+## Conan
+
+Additionally bmx (including MXF and MXF++) is available via the Conan package manager for C/C++: [bmx Conan recipe](https://conan.io/center/recipes/bmx). Conan Center Index offers precompiled packages for many target systems and otherwise allows to locally build according to a local conan build profile. Follow the code snippets and documentation on the linked page for integrating it.
+
 ## License
 
 The bmx library is provided under the BSD 3-clause license. See the [COPYING](./COPYING) file provided with this library for more details.

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ Source distributions, including dependencies, and binaries are made available in
 
 Source and binary distributions are generally only created when a new feature is required for creating standard compliant sample files for example, or when a release hasn't been made for a long time.
 
-## Conan
+### Conan
 
-Additionally bmx (including MXF and MXF++) is available via the Conan package manager for C/C++: [bmx Conan recipe](https://conan.io/center/recipes/bmx). Conan Center Index offers precompiled packages for many target systems and otherwise allows to locally build according to a local conan build profile. Follow the code snippets and documentation on the linked page for integrating it.
+Additionally bmx (including MXF and MXF++) is available via the Conan package manager for C/C++: [bmx Conan recipe](https://conan.io/center/recipes/bmx). Conan Center Index offers precompiled packages for many target systems and otherwise allows to build locally according to a local conan build profile. Follow the code snippets and documentation on the linked page for integrating it.
 
 ## License
 


### PR DESCRIPTION
Hey,

with the recipe for bmx merged into the conan center index today, I thought I'd propose mentioning its availability in the Readme in case you want it mentioned.

A few general comments/updates, not really related to the actual content of the MR but as context.

As discussed in #80, on Winodws it is only available as a static library, other systems offer both. I myself already use it since a while on macOS (aarch64) and Linux (x64).

It offers Version _1.2_ as it was the latest official release as well as _cci.20240517_. This follows a versioning scheme used in Conan for not officially tagged components. It was the state of the repo of bmx when all our build improvement suggestions had been merged. I'll keep watching bmx and will (try) to take care of updates when the next release is done etc.