### PR TITLE
Fix missing commandline output file arg in docs

### DIFF
--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -3568,6 +3568,11 @@ int main(int argc, const char** argv)
             log_info("Output filename set to '%s'\n", complete_output_name.c_str());
         }
 
+        if (complete_output_name.empty()) {
+            log_error("No output name given; use the '-o' option\n");
+            throw false;
+        }
+
 
         // create output clip and initialize
 

--- a/apps/raw2bmx/raw2bmx.cpp
+++ b/apps/raw2bmx/raw2bmx.cpp
@@ -4113,12 +4113,6 @@ int main(int argc, const char** argv)
         return 1;
     }
 
-    if (!output_name) {
-        usage_ref(argv[0]);
-        fprintf(stderr, "No output name given\n");
-        return 1;
-    }
-
     if (inputs.empty()) {
         usage_ref(argv[0]);
         fprintf(stderr, "No raw inputs given\n");
@@ -4995,6 +4989,11 @@ int main(int argc, const char** argv)
                                                                 filename_essence_type_names,
                                                                 mp_uid, fp_uid);
             log_info("Output filename set to '%s'\n", complete_output_name.c_str());
+        }
+
+        if (complete_output_name.empty()) {
+            log_error("No output name given; use the '-o' option\n");
+            throw false;
         }
 
 

--- a/docs/timed_text.md
+++ b/docs/timed_text.md
@@ -36,13 +36,13 @@ The `raw2bmx` utility can be used to embed Timed Text XML and ancillary font or 
 *Example 1*: Creates an OP1a file including a timed text track alongside video and audio tracks. The manifest file, `manifest.txt`, references the Timed Text XML file and ancillary resource files.
 
 ```bash
-raw2bmx -t op1a -y 10:00:00:00 --avci video.h264 --wave audio.wav --tt manifest.txt
+raw2bmx -t op1a -o output.mxf -y 10:00:00:00 --avci video.h264 --wave audio.wav --tt manifest.txt
 ```
 
 *Example 2*: Creates a (mono-essence) IMF Timed Text Track File. An edit rate (`-f`) and duration (`--dur`) are required in this case as they are not parsed from the Timed Text XML file (assuming they are specified in there).
 
 ```bash
-raw2bmx -t imf -f 25 --dur 100 --tt manifest.txt
+raw2bmx -t imf -o {Type}_{fp_uuid}.mxf -f 25 --dur 100 --tt manifest.txt
 ```
 
 ### Manifest File Format


### PR DESCRIPTION
and add a check to `raw2bmx` and `bmxtranswrap` to report an error if an output file is not set.