### PR TITLE
Precharge and postroll handling

### DIFF
--- a/src/mxf_op1a/OP1AFile.cpp
+++ b/src/mxf_op1a/OP1AFile.cpp
@@ -416,7 +416,9 @@ void OP1AFile::PrepareHeaderMetadata()
     for (i = 0; i < mTracks.size(); i++)
         mTracks[i]->PrepareWrite(mTrackCounts[mTracks[i]->GetDataDef()]);
     if (HAVE_PRIMARY_EC) {
-        mCPManager->SetStartTimecode(mStartTimecode);
+        Timecode start_timecode = mStartTimecode;
+        start_timecode.AddOffset(- mOutputStartOffset, mFrameRate);
+        mCPManager->SetStartTimecode(start_timecode);
         mCPManager->PrepareWrite();
         mIndexTable->PrepareWrite();
     }

--- a/src/mxf_reader/MXFFileReader.cpp
+++ b/src/mxf_reader/MXFFileReader.cpp
@@ -2325,7 +2325,15 @@ bool MXFFileReader::HaveInterFrameEncodingTrack() const
                 essence_type == MPEG2LG_MP_HL_1440_1080P ||
                 essence_type == MPEG2LG_MP_HL_720P ||
                 essence_type == MPEG2LG_MP_H14_1080I ||
-                essence_type == MPEG2LG_MP_H14_1080P)
+                essence_type == MPEG2LG_MP_H14_1080P ||
+                essence_type == AVC_BASELINE ||
+                essence_type == AVC_CONSTRAINED_BASELINE ||
+                essence_type == AVC_MAIN ||
+                essence_type == AVC_EXTENDED ||
+                essence_type == AVC_HIGH ||
+                essence_type == AVC_HIGH_10 ||
+                essence_type == AVC_HIGH_422 ||
+                essence_type == AVC_HIGH_444)
             {
                 return true;
             }

--- a/src/rdd9_mxf/RDD9File.cpp
+++ b/src/rdd9_mxf/RDD9File.cpp
@@ -332,7 +332,9 @@ void RDD9File::PrepareHeaderMetadata()
     for (i = 0; i < mTracks.size(); i++)
         mTracks[i]->PrepareWrite(mTrackCounts[mTracks[i]->GetDataDef()]);
 
-    mCPManager->SetStartTimecode(mStartTimecode);
+    Timecode start_timecode = mStartTimecode;
+    start_timecode.AddOffset(- mOutputStartOffset, mFrameRate);
+    mCPManager->SetStartTimecode(start_timecode);
     mCPManager->PrepareWrite();
     mIndexTable->PrepareWrite();
 


### PR DESCRIPTION
These patches enable precharge and rollout handling for AVC Long GOP and fix an inconsistency of the system item timecode when precharge is present. The inconsistency is also fixed for RDD9.