### PR TITLE
raw2bmx: Add support for ANC/VBI frame wrapped in KLV

### DIFF
--- a/include/bmx/essence_parser/CMakeLists.txt
+++ b/include/bmx/essence_parser/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND bmx_headers
     bmx/essence_parser/FileEssenceSource.h
     bmx/essence_parser/FilePatternEssenceSource.h
     bmx/essence_parser/J2CEssenceParser.h
+    bmx/essence_parser/KLVEssenceReader.h
     bmx/essence_parser/KLVEssenceSource.h
     bmx/essence_parser/MJPEGEssenceParser.h
     bmx/essence_parser/MPEG2AspectRatioFilter.h

--- a/include/bmx/essence_parser/KLVEssenceReader.h
+++ b/include/bmx/essence_parser/KLVEssenceReader.h
@@ -1,8 +1,6 @@
 /*
- * Copyright (C) 2013, British Broadcasting Corporation
+ * Copyright (C) 2024, British Broadcasting Corporation
  * All Rights Reserved.
- *
- * Author: Philip de Nier
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,62 +27,34 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef BMX_KLV_ESSENCE_SOURCE_H_
-#define BMX_KLV_ESSENCE_SOURCE_H_
+#ifndef BMX_KLV_ESSENCE_READER_H_
+#define BMX_KLV_ESSENCE_READER_H_
 
-
-#include <bmx/essence_parser/EssenceSource.h>
-
+#include <bmx/essence_parser/KLVEssenceSource.h>
+#include <bmx/ByteArray.h>
 
 
 namespace bmx
 {
 
-
-class KLVEssenceSource : public EssenceSource
+class KLVEssenceReader
 {
 public:
-    KLVEssenceSource(EssenceSource *child_source);
-    KLVEssenceSource(EssenceSource *child_source, const mxfKey *key);
-    KLVEssenceSource(EssenceSource *child_source, uint32_t track_num);
-    KLVEssenceSource(EssenceSource *child_source, const mxfKey *key, uint64_t start_value_len);
-    virtual ~KLVEssenceSource();
+    KLVEssenceReader(KLVEssenceSource *essence_source);
+    ~KLVEssenceReader();
 
-public:
-    virtual uint32_t Read(unsigned char *data, uint32_t size);
-    virtual bool SeekStart();
-    virtual bool Skip(int64_t offset);
+    uint32_t ReadValue();
 
-    virtual bool HaveError() const;
-    virtual int GetErrno() const;
-    virtual std::string GetStrError() const;
-
-public:
-    bool PositionInV(uint64_t *size);
-
-    uint64_t GetOffsetInV() const { return mValueLen - mRemValueLen; }
+    unsigned char* GetValue() const { return mValueBuffer.GetBytes(); }
+    uint32_t GetValueSize() const   { return mValueBuffer.GetSize(); }
 
 private:
-    typedef enum
-    {
-        READ_KL_STATE,
-        READ_V_STATE,
-        READ_END_STATE,
-    } KLVState;
-
-private:
-    EssenceSource *mChildSource;
-    mxfKey mKey;
-    uint32_t mTrackNum;
-    KLVState mState;
-    uint64_t mValueLen;
-    uint64_t mRemValueLen;
+    KLVEssenceSource *mEssenceSource;
+    ByteArray mValueBuffer;
 };
 
 
 };
-
 
 
 #endif
-

--- a/src/essence_parser/CMakeLists.txt
+++ b/src/essence_parser/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND bmx_sources
     essence_parser/FileEssenceSource.cpp
     essence_parser/FilePatternEssenceSource.cpp
     essence_parser/J2CEssenceParser.cpp
+    essence_parser/KLVEssenceReader.cpp
     essence_parser/KLVEssenceSource.cpp
     essence_parser/MJPEGEssenceParser.cpp
     essence_parser/MPEG2AspectRatioFilter.cpp


### PR DESCRIPTION
This adds support for wrapping variable size ANC and VBI using raw2bmx. This will be used to add a test for variable size ANC/VBI and video.