### PR TITLE
Build release on Ubuntu and use source release from Ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,24 +2,10 @@ name: Release
 on:
   workflow_dispatch:
 jobs:
-  binary_release:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: windows
-            os: windows-2019
-          - name: macos-xcode-universal
-            os: macos-13
-
-    runs-on: ${{ matrix.os }}
+  source_release:
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        if: ${{ contains(matrix.name, 'xcode') }}
-        with:
-          xcode-version: latest-stable
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -30,37 +16,13 @@ jobs:
         run: |
           cmake -P bmx/release/source_release.cmake
 
-      - name: Win64 binary release
-        if: ${{ contains(matrix.name, 'windows') }}
-        shell: bash
-        working-directory: ../
-        run: |
-          mkdir binary_release
-          cd binary_release
-          unzip -q ../source_release/bmx-*.zip
-          cd bmx-*
-          cmake -P release/win64_binary_release.cmake
-
-      - name: MacOS Universal binary release
-        if: ${{ contains(matrix.os, 'macos') }}
-        shell: bash
-        working-directory: ../
-        run: |
-          mkdir binary_release
-          cd binary_release
-          unzip -q ../source_release/bmx-*.zip
-          cd bmx-*
-          cmake -P release/macos_universal_binary_release.cmake
-
       # actions/upload-artifact doesn't allow . and .. in paths
-      - name: Move artefacts into working directory
+      - name: Move source artefacts into working directory
         shell: bash
         run: |
           mv ../source_release .
-          mv ../binary_release/bmx-*/out/package ./binary_release
 
       - name: Upload source release
-        if: ${{ contains(matrix.name, 'windows') }}
         uses: actions/upload-artifact@v4
         with:
           name: source-release
@@ -68,9 +30,86 @@ jobs:
             source_release/*.zip
             source_release/*.tar.gz
 
+  binary_release:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows
+            os: windows-2019
+          - name: macos-xcode-universal
+            os: macos-13
+          - name: ubuntu
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+    needs: source_release
+
+    steps:
+      - name: Install dependencies (ubuntu)
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install \
+            git \
+            pkg-config \
+            g++ \
+            gcc \
+            cmake \
+            uuid-dev \
+            libcurl4-openssl-dev
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        if: ${{ contains(matrix.name, 'xcode') }}
+        with:
+          xcode-version: latest-stable
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-release
+
+      - name: Win64 binary release
+        if: ${{ contains(matrix.name, 'windows') }}
+        shell: bash
+        run: |
+          mkdir binary_release
+          cd binary_release
+          unzip -q ../bmx-*.zip
+          cd bmx-*
+          cmake -P release/win64_binary_release.cmake
+
+      - name: MacOS Universal binary release
+        if: ${{ contains(matrix.os, 'macos') }}
+        shell: bash
+        run: |
+          mkdir binary_release
+          cd binary_release
+          unzip -q ../bmx-*.zip
+          cd bmx-*
+          cmake -P release/macos_universal_binary_release.cmake
+
+      - name: Ubuntu binary build (build only, no artefacts)
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        shell: bash
+        run: |
+          mkdir binary_release
+          cd binary_release
+          tar -xzf ../bmx-*.tar.gz
+          cd bmx-*
+          cmake -P release/ubuntu_binary_release_build_only.cmake
+
+      # actions/upload-artifact doesn't allow . and .. in paths
+      - name: Move binary artefacts into binary_release directory
+        if: ${{ !contains(matrix.os, 'ubuntu') }}
+        shell: bash
+        run: |
+          mv binary_release/bmx-*/out/package/bmx-*.zip ./binary_release
+
       - name: Upload binary release
+        if: ${{ !contains(matrix.os, 'ubuntu') }}
         uses: actions/upload-artifact@v4
         with:
           name: binary-release-${{ matrix.name }}
           path: |
-            binary_release/*.zip
+            binary_release/bmx-*.zip

--- a/release/ubuntu_binary_release_build_only.cmake
+++ b/release/ubuntu_binary_release_build_only.cmake
@@ -1,0 +1,53 @@
+# Build bmx on Ubuntu using the source release.
+
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+if(NOT DEFINED BMX_BRANCH)
+    set(BMX_BRANCH main)
+endif()
+if(NOT DEFINED USE_GIT_CLONE)
+    set(USE_GIT_CLONE OFF)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
+
+
+function(copy_and_rename_file source dest)
+    get_filename_component(dest_dir ${dest} DIRECTORY)
+    get_filename_component(source_name ${source} NAME)
+    file(COPY ${source} DESTINATION ${dest_dir})
+    file(RENAME ${dest_dir}/${source_name} ${dest})
+endfunction()
+
+
+if(USE_GIT_CLONE)
+    # Clone bmx
+    set(bmx_dir "${CMAKE_CURRENT_BINARY_DIR}/bmx")
+    if(EXISTS ${bmx_dir})
+        message(FATAL_ERROR "Can't continue with clean release as 'bmx' directory already exists")
+    endif()
+    run_command("${CMAKE_CURRENT_BINARY_DIR}" git clone https://github.com/bbc/bmx.git)
+    run_command("${bmx_dir}" git checkout ${BMX_BRANCH})
+else()
+    get_filename_component(bmx_dir "${CMAKE_CURRENT_LIST_DIR}/.." REALPATH)
+    if(EXISTS ${bmx_dir}/out)
+        message(FATAL_ERROR "Can't continue with clean release as 'out' sub-directory already exists")
+    endif()
+endif()
+
+# Create build, install and package directories
+set(build_dir "${bmx_dir}/out/build")
+file(MAKE_DIRECTORY ${build_dir})
+set(install_dir "${bmx_dir}/out/install")
+file(MAKE_DIRECTORY ${install_dir})
+
+extract_version("${bmx_dir}/CMakeLists.txt" bmx_version)
+set(package_dir "${bmx_dir}/out/package")
+set(bmx_package_dir "${package_dir}/bmx-ubuntu-binary-${bmx_version}")
+file(MAKE_DIRECTORY ${bmx_package_dir})
+
+# Configure, build, test and install
+run_command("${build_dir}" cmake -DCMAKE_INSTALL_PREFIX=../install -DBMX_BUILD_URIPARSER_SOURCE=ON -DBMX_BUILD_EXPAT_SOURCE=ON -DBMX_BUILD_WITH_LIBCURL=ON -DCMAKE_BUILD_TYPE=Release ../../)
+run_command("${build_dir}" cmake --build .)
+run_command("${build_dir}" ctest --output-on-failure)
+run_command("${build_dir}" cmake --build . --target install)


### PR DESCRIPTION
This PR fixes #108 by creating the source release on Ubuntu rather than Windows.

This PR also
* creates a single source release (on Ubuntu) rather than a different one for each OS. This singular source release is used to build the Windows and macOS binary releases.
* adds an Ubuntu build for testing, but the binary artefacts are not used for the release
