### PR TITLE
Add support for Linux arm64 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-> [!IMPORTANT]
-> Seeking input about the ongoing maintenance and future shape of the project. Please provide any thoughts and suggestions in issue [#114](https://github.com/bbc/bmx/issues/114)
+> [!TIP]
+> **The [original bmx repositiory](https://github.com/bbc/bmx) has now been archived.**
+> **This fork has been made available to the bmx community to continue development of the project, as discussed in https://github.com/bbc/bmx/issues/114**
 
 # bmx Library and Utilities
 

--- a/deps/libMXF/tools/MXFDump/MXFDump.cpp
+++ b/deps/libMXF/tools/MXFDump/MXFDump.cpp
@@ -61,6 +61,9 @@
 #elif defined(__GNUC__) && defined(__x86_64__) && defined(__linux__)
 #define MXF_COMPILER_GCC_X86_64_LINUX
 #define MXF_OS_UNIX
+#elif defined(__GNUC__) && defined(__aarch64__) && defined(__linux__)
+#define MXF_COMPILER_GCC_ARM64_LINUX
+#define MXF_OS_UNIX
 #elif defined(__MWERKS__) && defined(__POWERPC__) && defined(macintosh)
 #define MXF_COMPILER_MWERKS_PPC_MACOS
 #define MXF_OS_MACOS
@@ -221,7 +224,7 @@ typedef unsigned long long int mxfUInt64;
 #define MXFPRIx16 "hx"
 #define MXFPRIx32 "x"
 #define MXFPRIx64 "llx"
-#elif defined(MXF_COMPILER_GCC_ARM64_MACOSX)
+#elif defined(MXF_COMPILER_GCC_ARM64_MACOSX) || defined(MXF_COMPILER_GCC_ARM64_LINUX)
 typedef unsigned char          mxfUInt08;
 typedef unsigned short int     mxfUInt16;
 typedef unsigned int           mxfUInt32;


### PR DESCRIPTION
Hey,

I just wanted to build bmx on an arm64 linux system and it failed the compiler detection in `MXFDump.cpp`. So I just tried to added support. Not sure it is the perfect way, but at least the defines seem to be the ones to detect and arm64 system on Linux arm64.