### PR TITLE
Fix growing AVC file descriptor header

### DIFF
--- a/apps/bmxtranswrap/bmxtranswrap.cpp
+++ b/apps/bmxtranswrap/bmxtranswrap.cpp
@@ -4015,6 +4015,7 @@ int main(int argc, const char** argv)
         // initialise output tracks
 
         unsigned char avci_header_data[AVCI_HEADER_SIZE];
+        bool update_header = false;
         for (i = 0; i < output_tracks.size(); i++) {
             OutputTrack *output_track = output_tracks[i];
 
@@ -4199,6 +4200,7 @@ int main(int argc, const char** argv)
                         clip_track->SetAspectRatio(user_aspect_ratio);
                     if (afd)
                         clip_track->SetAFD(afd);
+                    update_header = true;
                     break;
                 case UNC_SD:
                 case UNC_HD_1080I:
@@ -4911,6 +4913,10 @@ int main(int argc, const char** argv)
                 even_frame = !even_frame;
             }
 
+            if (update_header) {
+                clip->UpdateHeaderMetadata();
+                update_header = false;
+            }
 
             total_read += num_read;
 

--- a/apps/raw2bmx/raw2bmx.cpp
+++ b/apps/raw2bmx/raw2bmx.cpp
@@ -5374,6 +5374,7 @@ int main(int argc, const char** argv)
         // initialize output clip tracks
 
         unsigned char avci_header_data[AVCI_HEADER_SIZE];
+        bool update_header = false;
         for (i = 0; i < output_tracks.size(); i++) {
             OutputTrack *output_track = output_tracks[i];
 
@@ -5503,6 +5504,7 @@ int main(int argc, const char** argv)
                         clip_track->SetAspectRatio(input->aspect_ratio);
                     if (BMX_OPT_PROP_IS_SET(input->afd))
                         clip_track->SetAFD(input->afd);
+                    update_header = true;
                     break;
                 case UNC_SD:
                 case UNC_HD_1080I:
@@ -6279,6 +6281,11 @@ int main(int argc, const char** argv)
                 OutputTrack *output_track = output_tracks[i];
                 if (output_track->IsSilenceTrack())
                     output_track->WriteSilenceSamples(first_sound_num_samples);
+            }
+
+            if (update_header) {
+                clip->UpdateHeaderMetadata();
+                update_header = false;
             }
 
             if (min_num_samples < max_samples_per_read)

--- a/include/bmx/clip_writer/ClipWriter.h
+++ b/include/bmx/clip_writer/ClipWriter.h
@@ -88,6 +88,7 @@ public:
     void PrepareHeaderMetadata();
     void PrepareWrite();
     void WriteSamples(uint32_t track_index, const unsigned char *data, uint32_t size, uint32_t num_samples);
+    void UpdateHeaderMetadata();
     void CompleteWrite();
 
 public:

--- a/include/bmx/mxf_op1a/OP1AFile.h
+++ b/include/bmx/mxf_op1a/OP1AFile.h
@@ -124,6 +124,7 @@ public:
     void PrepareWrite();
     void WriteUserTimecode(Timecode user_timecode);
     void WriteSamples(uint32_t track_index, const unsigned char *data, uint32_t size, uint32_t num_samples);
+    void UpdateHeaderMetadata();
     void CompleteWrite();
 
 public:

--- a/src/clip_writer/ClipWriter.cpp
+++ b/src/clip_writer/ClipWriter.cpp
@@ -535,6 +535,19 @@ void ClipWriter::CompleteWrite()
     }
 }
 
+void ClipWriter::UpdateHeaderMetadata()
+{
+    switch (mType)
+    {
+        case CW_OP1A_CLIP_TYPE:
+            mOP1AClip->UpdateHeaderMetadata();
+            break;
+        case CW_UNKNOWN_CLIP_TYPE:
+            BMX_ASSERT(false);
+            break;
+    }
+}
+
 HeaderMetadata* ClipWriter::GetHeaderMetadata() const
 {
     switch (mType)


### PR DESCRIPTION
Update the MXF header metadata after the first frame so that the parsed AVC descriptor metadata are available from the beginning.